### PR TITLE
Add retry support to client SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ npm install stateset-node
 ```javascript
 import stateset from 'stateset-node';
 
-const client = new stateset({apiKey: process.env.STATESET_API_KEY});
+const client = new stateset({
+  apiKey: process.env.STATESET_API_KEY,
+  // Optional retry logic for transient failures
+  retry: 3,
+  retryDelayMs: 1000,
+});
 ```
 
 3. **Make an API call**

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,0 +1,5 @@
+import stateset from '../src';
+
+test('exports stateset class', () => {
+  expect(typeof stateset).toBe('function');
+});

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,2 @@
+import { stateset } from './stateset-client';
+export default stateset;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,4 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const stateset_client_1 = require("./stateset-client");
+exports.default = stateset_client_1.stateset;

--- a/dist/stateset-client.d.ts
+++ b/dist/stateset-client.d.ts
@@ -1,3 +1,4 @@
+import { AxiosRequestConfig } from 'axios';
 import Returns from './lib/resources/Return';
 import Warranties from './lib/resources/Warranty';
 import Products from './lib/resources/Product';
@@ -47,14 +48,37 @@ import Promotions from './lib/resources/Promotion';
 import Schedule from './lib/resources/Schedule';
 import ShipTo from './lib/resources/ShipTo';
 import Logs from './lib/resources/Log';
+import MaintenanceSchedules from './lib/resources/MaintenanceSchedule';
+import QualityControl from './lib/resources/QualityControl';
+import ResourceUtilization from './lib/resources/ResourceUtilization';
+import Payments from './lib/resources/Payment';
+import Refunds from './lib/resources/Refund';
+import CreditsDebits from './lib/resources/CreditsDebits';
+import Ledger from './lib/resources/Ledger';
+import Opportunities from './lib/resources/Opportunity';
+import Contacts from './lib/resources/Contact';
+import CasesTickets from './lib/resources/CaseTicket';
+import Carriers from './lib/resources/Carrier';
+import Routes from './lib/resources/Route';
+import DeliveryConfirmations from './lib/resources/DeliveryConfirmation';
 interface StatesetOptions {
     apiKey: string;
     baseUrl?: string;
+    /**
+     * Number of times to retry a failed request. Defaults to 0 (no retries).
+     */
+    retry?: number;
+    /**
+     * Delay in milliseconds between retries.
+     */
+    retryDelayMs?: number;
 }
 export declare class stateset {
     private baseUrl;
     private apiKey;
     private httpClient;
+    private retry;
+    private retryDelayMs;
     returns: Returns;
     returnItems: ReturnLines;
     warranties: Warranties;
@@ -104,7 +128,20 @@ export declare class stateset {
     contracts: Contracts;
     promotions: Promotions;
     logs: Logs;
+    maintenanceSchedules: MaintenanceSchedules;
+    qualityControl: QualityControl;
+    resourceUtilization: ResourceUtilization;
+    payments: Payments;
+    refunds: Refunds;
+    creditsDebits: CreditsDebits;
+    ledger: Ledger;
+    opportunities: Opportunities;
+    contacts: Contacts;
+    casesTickets: CasesTickets;
+    carriers: Carriers;
+    routes: Routes;
+    deliveryConfirmations: DeliveryConfirmations;
     constructor(options: StatesetOptions);
-    request(method: string, path: string, data?: any, options?: any): Promise<any>;
+    request(method: string, path: string, data?: any, options?: AxiosRequestConfig): Promise<any>;
 }
 export default stateset;

--- a/dist/stateset-client.js
+++ b/dist/stateset-client.js
@@ -54,16 +54,46 @@ const Promotion_1 = __importDefault(require("./lib/resources/Promotion"));
 const Schedule_1 = __importDefault(require("./lib/resources/Schedule"));
 const ShipTo_1 = __importDefault(require("./lib/resources/ShipTo"));
 const Log_1 = __importDefault(require("./lib/resources/Log"));
+const MaintenanceSchedule_1 = __importDefault(require("./lib/resources/MaintenanceSchedule"));
+const QualityControl_1 = __importDefault(require("./lib/resources/QualityControl"));
+const ResourceUtilization_1 = __importDefault(require("./lib/resources/ResourceUtilization"));
+const Payment_1 = __importDefault(require("./lib/resources/Payment"));
+const Refund_1 = __importDefault(require("./lib/resources/Refund"));
+const CreditsDebits_1 = __importDefault(require("./lib/resources/CreditsDebits"));
+const Ledger_1 = __importDefault(require("./lib/resources/Ledger"));
+const Opportunity_1 = __importDefault(require("./lib/resources/Opportunity"));
+const Contact_1 = __importDefault(require("./lib/resources/Contact"));
+const CaseTicket_1 = __importDefault(require("./lib/resources/CaseTicket"));
+const Carrier_1 = __importDefault(require("./lib/resources/Carrier"));
+const Route_1 = __importDefault(require("./lib/resources/Route"));
+const DeliveryConfirmation_1 = __importDefault(require("./lib/resources/DeliveryConfirmation"));
 class stateset {
     constructor(options) {
+        var _a, _b;
         this.apiKey = options.apiKey;
         this.baseUrl = options.baseUrl || 'https://stateset-proxy-server.stateset.cloud.stateset.app/api';
+        this.retry = (_a = options.retry) !== null && _a !== void 0 ? _a : 0;
+        this.retryDelayMs = (_b = options.retryDelayMs) !== null && _b !== void 0 ? _b : 1000;
         this.httpClient = axios_1.default.create({
             baseURL: this.baseUrl,
             headers: {
                 Authorization: `Bearer ${this.apiKey}`,
                 'Content-Type': 'application/json'
             }
+        });
+        // Simple automatic retry mechanism for transient failures
+        this.httpClient.interceptors.response.use((resp) => resp, async (error) => {
+            const config = error.config;
+            if (!config || this.retry <= 0) {
+                return Promise.reject(error);
+            }
+            config.__retryCount = config.__retryCount || 0;
+            if (config.__retryCount >= this.retry) {
+                return Promise.reject(error);
+            }
+            config.__retryCount += 1;
+            await new Promise((resolve) => setTimeout(resolve, this.retryDelayMs));
+            return this.httpClient.request(config);
         });
         this.returns = new Return_1.default(this);
         this.returnItems = new ReturnLine_1.default(this);
@@ -114,6 +144,19 @@ class stateset {
         this.contracts = new Contract_1.default(this);
         this.promotions = new Promotion_1.default(this);
         this.logs = new Log_1.default(this);
+        this.maintenanceSchedules = new MaintenanceSchedule_1.default(this);
+        this.qualityControl = new QualityControl_1.default(this);
+        this.resourceUtilization = new ResourceUtilization_1.default(this);
+        this.payments = new Payment_1.default(this);
+        this.refunds = new Refund_1.default(this);
+        this.creditsDebits = new CreditsDebits_1.default(this);
+        this.ledger = new Ledger_1.default(this);
+        this.opportunities = new Opportunity_1.default(this);
+        this.contacts = new Contact_1.default(this);
+        this.casesTickets = new CaseTicket_1.default(this);
+        this.carriers = new Carrier_1.default(this);
+        this.routes = new Route_1.default(this);
+        this.deliveryConfirmations = new DeliveryConfirmation_1.default(this);
     }
     async request(method, path, data, options = {}) {
         try {

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,0 @@
-import { stateset } from './src/stateset-client';
-
-export default stateset;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+import { stateset } from './stateset-client';
+
+export default stateset;


### PR DESCRIPTION
## Summary
- move entry point into `src` for proper build output
- add simple automatic retry logic
- document retry options
- add Jest config and minimal test

## Testing
- `npm test`
- `npm run build`
