### PR TITLE
Improve SDK configuration via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ npm install stateset-node
 import stateset from 'stateset-node';
 
 const client = new stateset({
+  // apiKey and baseUrl can be omitted if the STATESET_API_KEY and
+  // STATESET_BASE_URL environment variables are set.
   apiKey: process.env.STATESET_API_KEY,
   // Optional retry logic for transient failures
   retry: 3,
@@ -69,6 +71,7 @@ This repository contains sample Node and web apps demonstrating how the SDK can 
 2. **Obtain an API key from the Stateset Cloud Platform Dashboard.**
 3. **Navigate to the `samples` folder and run `npm install`.**
 4. **Set your API key as an environment variable: `export STATESET_API_KEY=YOUR_API_KEY`.**
+   You can also override the API base URL with `export STATESET_BASE_URL=https://your-endpoint`.
 5. **Open the sample file you're interested in, e.g., `returns_list.js`.**
 6. **Run the sample file: `node returns_list.js`.**
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -9,3 +9,16 @@ test('sets default timeout and user agent', () => {
   expect(client.httpClient.defaults.timeout).toBe(60000);
   expect(client.httpClient.defaults.headers['User-Agent']).toMatch(/^stateset-node\//);
 });
+
+test('uses environment variables when options are omitted', () => {
+  process.env.STATESET_API_KEY = 'env-key';
+  process.env.STATESET_BASE_URL = 'https://example.com/api';
+
+  const client: any = new stateset({});
+
+  expect(client.httpClient.defaults.baseURL).toBe('https://example.com/api');
+  expect(client.httpClient.defaults.headers['Authorization']).toBe('Bearer env-key');
+
+  delete process.env.STATESET_API_KEY;
+  delete process.env.STATESET_BASE_URL;
+});

--- a/dist/stateset-client.d.ts
+++ b/dist/stateset-client.d.ts
@@ -62,7 +62,7 @@ import Carriers from './lib/resources/Carrier';
 import Routes from './lib/resources/Route';
 import DeliveryConfirmations from './lib/resources/DeliveryConfirmation';
 interface StatesetOptions {
-    apiKey: string;
+    apiKey?: string;
     baseUrl?: string;
     /**
      * Number of times to retry a failed request. Defaults to 0 (no retries).
@@ -72,6 +72,14 @@ interface StatesetOptions {
      * Delay in milliseconds between retries.
      */
     retryDelayMs?: number;
+    /**
+     * Request timeout in milliseconds. Defaults to 60000 (60s).
+     */
+    timeout?: number;
+    /**
+     * Custom User-Agent header value. Defaults to `stateset-node/<version>`.
+     */
+    userAgent?: string;
 }
 export declare class stateset {
     private baseUrl;
@@ -79,6 +87,8 @@ export declare class stateset {
     private httpClient;
     private retry;
     private retryDelayMs;
+    private timeout;
+    private userAgent;
     returns: Returns;
     returnItems: ReturnLines;
     warranties: Warranties;

--- a/dist/stateset-client.js
+++ b/dist/stateset-client.js
@@ -5,6 +5,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.stateset = void 0;
 const axios_1 = __importDefault(require("axios"));
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const packageVersion = require('../package.json').version;
 const Return_1 = __importDefault(require("./lib/resources/Return"));
 const Warranty_1 = __importDefault(require("./lib/resources/Warranty"));
 const Product_1 = __importDefault(require("./lib/resources/Product"));
@@ -69,16 +71,26 @@ const Route_1 = __importDefault(require("./lib/resources/Route"));
 const DeliveryConfirmation_1 = __importDefault(require("./lib/resources/DeliveryConfirmation"));
 class stateset {
     constructor(options) {
-        var _a, _b;
-        this.apiKey = options.apiKey;
-        this.baseUrl = options.baseUrl || 'https://stateset-proxy-server.stateset.cloud.stateset.app/api';
+        var _a, _b, _c;
+        this.apiKey = options.apiKey || process.env.STATESET_API_KEY || '';
+        this.baseUrl =
+            options.baseUrl ||
+                process.env.STATESET_BASE_URL ||
+                'https://stateset-proxy-server.stateset.cloud.stateset.app/api';
+        if (!this.apiKey) {
+            throw new Error('Stateset API key is required');
+        }
         this.retry = (_a = options.retry) !== null && _a !== void 0 ? _a : 0;
         this.retryDelayMs = (_b = options.retryDelayMs) !== null && _b !== void 0 ? _b : 1000;
+        this.timeout = (_c = options.timeout) !== null && _c !== void 0 ? _c : 60000;
+        this.userAgent = options.userAgent || `stateset-node/${packageVersion}`;
         this.httpClient = axios_1.default.create({
             baseURL: this.baseUrl,
+            timeout: this.timeout,
             headers: {
                 Authorization: `Bearer ${this.apiKey}`,
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'User-Agent': this.userAgent
             }
         });
         // Simple automatic retry mechanism for transient failures

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stateset-node",
-  "version": "0.0.89",
+  "version": "0.0.90",
   "description": "TypeScript/Node.js library for the Stateset API",
   "keywords": [
     "stateset",

--- a/src/stateset-client.ts
+++ b/src/stateset-client.ts
@@ -65,7 +65,7 @@ import Routes from './lib/resources/Route';
 import DeliveryConfirmations from './lib/resources/DeliveryConfirmation';
 
 interface StatesetOptions {
-  apiKey: string;
+  apiKey?: string;
   baseUrl?: string;
   /**
    * Number of times to retry a failed request. Defaults to 0 (no retries).
@@ -157,8 +157,15 @@ export class stateset {
   public deliveryConfirmations: DeliveryConfirmations;
 
   constructor(options: StatesetOptions) {
-    this.apiKey = options.apiKey;
-    this.baseUrl = options.baseUrl || 'https://stateset-proxy-server.stateset.cloud.stateset.app/api';
+    this.apiKey = options.apiKey || process.env.STATESET_API_KEY || '';
+    this.baseUrl =
+      options.baseUrl ||
+      process.env.STATESET_BASE_URL ||
+      'https://stateset-proxy-server.stateset.cloud.stateset.app/api';
+
+    if (!this.apiKey) {
+      throw new Error('Stateset API key is required');
+    }
     this.retry = options.retry ?? 0;
     this.retryDelayMs = options.retryDelayMs ?? 1000;
     this.timeout = options.timeout ?? 60000;


### PR DESCRIPTION
## Summary
- add ability to configure API key and base URL via env vars
- document environment variable usage
- bump version to 0.0.90
- test new configuration behavior

## Testing
- `npm test`
