### PR TITLE
Add custom header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ const client = new stateset({
   retryDelayMs: 1000,
   // Optional request timeout and custom User-Agent
   timeout: 60000,
-  userAgent: 'my-app/1.0'
+  userAgent: 'my-app/1.0',
+  // Additional headers sent with every request
+  additionalHeaders: { 'X-Customer-ID': 'abc123' }
 });
 ```
 
@@ -57,6 +59,7 @@ The SDK exposes helper methods to update the API key, base URL and timeout on an
 client.setApiKey('new-key');
 client.setBaseUrl('https://api.example.com');
 client.setTimeout(30000);
+client.setHeaders({ 'X-Customer-ID': 'abc123' });
 ```
 
 3. **Make an API call**

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -29,7 +29,19 @@ test('allows updating configuration after init', () => {
   client.setBaseUrl('https://b');
   client.setTimeout(12345);
 
+  client.setHeaders({ 'X-Test': 'true' });
+
   expect(client.httpClient.defaults.headers['Authorization']).toBe('Bearer new-key');
   expect(client.httpClient.defaults.baseURL).toBe('https://b');
   expect(client.httpClient.defaults.timeout).toBe(12345);
+  expect(client.httpClient.defaults.headers['X-Test']).toBe('true');
+});
+
+test('applies additional headers from options', () => {
+  const client: any = new stateset({
+    apiKey: 'test',
+    additionalHeaders: { 'X-Example': 'example' }
+  });
+
+  expect(client.httpClient.defaults.headers['X-Example']).toBe('example');
 });

--- a/src/stateset-client.ts
+++ b/src/stateset-client.ts
@@ -83,6 +83,10 @@ interface StatesetOptions {
    * Custom User-Agent header value. Defaults to `stateset-node/<version>`.
    */
   userAgent?: string;
+  /**
+   * Additional headers to include with every request.
+   */
+  additionalHeaders?: Record<string, string>;
 }
 
 export class stateset {
@@ -93,6 +97,7 @@ export class stateset {
   private retryDelayMs: number;
   private timeout: number;
   private userAgent: string;
+  private additionalHeaders: Record<string, string>;
   public returns: Returns;
   public returnItems: ReturnLines;
   public warranties: Warranties;
@@ -170,6 +175,7 @@ export class stateset {
     this.retryDelayMs = options.retryDelayMs ?? 1000;
     this.timeout = options.timeout ?? 60000;
     this.userAgent = options.userAgent || `stateset-node/${packageVersion}`;
+    this.additionalHeaders = options.additionalHeaders || {};
 
     this.httpClient = axios.create({
       baseURL: this.baseUrl,
@@ -177,7 +183,8 @@ export class stateset {
       headers: {
         Authorization: `Bearer ${this.apiKey}`,
         'Content-Type': 'application/json',
-        'User-Agent': this.userAgent
+        'User-Agent': this.userAgent,
+        ...this.additionalHeaders
       }
     });
     // Simple automatic retry mechanism for transient failures
@@ -286,6 +293,15 @@ export class stateset {
   setTimeout(timeout: number): void {
     this.timeout = timeout;
     this.httpClient.defaults.timeout = timeout;
+  }
+
+  /**
+   * Merge additional headers to include with every request.
+   * @param headers - headers object
+   */
+  setHeaders(headers: Record<string, string>): void {
+    this.additionalHeaders = { ...this.additionalHeaders, ...headers };
+    Object.assign(this.httpClient.defaults.headers, this.additionalHeaders);
   }
 
   async request(method: string, path: string, data?: any, options: AxiosRequestConfig = {}) {


### PR DESCRIPTION
## Summary
- allow passing `additionalHeaders` option to client
- expose `setHeaders` to update headers after init
- document new header configuration in README
- test custom header behaviors

## Testing
- `npm test`