### PR TITLE
Add retry config API

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ const client = new stateset({
 });
 ```
 
+Retry behaviour can also be configured using the `STATESET_RETRY` and
+`STATESET_RETRY_DELAY_MS` environment variables.
+
 ### Updating configuration after initialization
 
 The SDK exposes helper methods to update the API key, base URL and timeout on an existing client instance:
@@ -59,6 +62,7 @@ The SDK exposes helper methods to update the API key, base URL and timeout on an
 client.setApiKey('new-key');
 client.setBaseUrl('https://api.example.com');
 client.setTimeout(30000);
+client.setRetryOptions(5, 500);
 client.setHeaders({ 'X-Customer-ID': 'abc123' });
 ```
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -14,13 +14,20 @@ test('uses environment variables when options are omitted', () => {
   process.env.STATESET_API_KEY = 'env-key';
   process.env.STATESET_BASE_URL = 'https://example.com/api';
 
+  process.env.STATESET_RETRY = '2';
+  process.env.STATESET_RETRY_DELAY_MS = '1500';
+
   const client: any = new stateset({});
 
   expect(client.httpClient.defaults.baseURL).toBe('https://example.com/api');
   expect(client.httpClient.defaults.headers['Authorization']).toBe('Bearer env-key');
+  expect(client.retry).toBe(2);
+  expect(client.retryDelayMs).toBe(1500);
 
   delete process.env.STATESET_API_KEY;
   delete process.env.STATESET_BASE_URL;
+  delete process.env.STATESET_RETRY;
+  delete process.env.STATESET_RETRY_DELAY_MS;
 });
 
 test('allows updating configuration after init', () => {
@@ -28,12 +35,15 @@ test('allows updating configuration after init', () => {
   client.setApiKey('new-key');
   client.setBaseUrl('https://b');
   client.setTimeout(12345);
+  client.setRetryOptions(5, 2000);
 
   client.setHeaders({ 'X-Test': 'true' });
 
   expect(client.httpClient.defaults.headers['Authorization']).toBe('Bearer new-key');
   expect(client.httpClient.defaults.baseURL).toBe('https://b');
   expect(client.httpClient.defaults.timeout).toBe(12345);
+  expect(client.retry).toBe(5);
+  expect(client.retryDelayMs).toBe(2000);
   expect(client.httpClient.defaults.headers['X-Test']).toBe('true');
 });
 

--- a/src/stateset-client.ts
+++ b/src/stateset-client.ts
@@ -171,8 +171,15 @@ export class stateset {
     if (!this.apiKey) {
       throw new Error('Stateset API key is required');
     }
-    this.retry = options.retry ?? 0;
-    this.retryDelayMs = options.retryDelayMs ?? 1000;
+    const envRetry = process.env.STATESET_RETRY
+      ? parseInt(process.env.STATESET_RETRY, 10)
+      : undefined;
+    const envRetryDelay = process.env.STATESET_RETRY_DELAY_MS
+      ? parseInt(process.env.STATESET_RETRY_DELAY_MS, 10)
+      : undefined;
+
+    this.retry = options.retry ?? envRetry ?? 0;
+    this.retryDelayMs = options.retryDelayMs ?? envRetryDelay ?? 1000;
     this.timeout = options.timeout ?? 60000;
     this.userAgent = options.userAgent || `stateset-node/${packageVersion}`;
     this.additionalHeaders = options.additionalHeaders || {};
@@ -293,6 +300,16 @@ export class stateset {
   setTimeout(timeout: number): void {
     this.timeout = timeout;
     this.httpClient.defaults.timeout = timeout;
+  }
+
+  /**
+   * Update retry configuration used for requests.
+   * @param retry - number of retries
+   * @param retryDelayMs - delay in ms between retries
+   */
+  setRetryOptions(retry: number, retryDelayMs: number = this.retryDelayMs): void {
+    this.retry = retry;
+    this.retryDelayMs = retryDelayMs;
   }
 
   /**


### PR DESCRIPTION
## Summary
- allow configuring retry options via environment variables and method
- document retry environment variables and method
- test new retry configuration features

## Testing
- `npm test`