### PR TITLE
Add search and notes retrieval for case tickets

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ await client.casesTickets.addNote(ticket.id, 'Customer will provide photos.');
 await client.casesTickets.escalate(ticket.id, 'HIGH');
 await client.casesTickets.close(ticket.id);
 await client.casesTickets.reopen(ticket.id, 'Additional information received.');
+
+const searchResults = await client.casesTickets.search('damaged', {
+  status: 'OPEN'
+});
+console.log(searchResults.cases_tickets);
+
+const notes = await client.casesTickets.listNotes(ticket.id);
+console.log(notes);
 ```
 
 ## Try out a sample app

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -55,3 +55,9 @@ test('applies additional headers from options', () => {
 
   expect(client.httpClient.defaults.headers['X-Example']).toBe('example');
 });
+
+test('exposes customer service helper methods', () => {
+  const client: any = new stateset({ apiKey: 'test-key' });
+  expect(typeof client.casesTickets.search).toBe('function');
+  expect(typeof client.casesTickets.listNotes).toBe('function');
+});

--- a/dist/lib/resources/CaseTicket.d.ts
+++ b/dist/lib/resources/CaseTicket.d.ts
@@ -75,6 +75,20 @@ export default class CasesTickets {
             offset: number;
         };
     }>;
+    search(query: string, params?: {
+        status?: CaseTicketStatus;
+        priority?: CaseTicketPriority;
+        org_id?: string;
+        limit?: number;
+        offset?: number;
+    }): Promise<{
+        cases_tickets: CaseTicketResponse[];
+        pagination: {
+            total: number;
+            limit: number;
+            offset: number;
+        };
+    }>;
     get(caseTicketId: NonEmptyString<string>): Promise<CaseTicketResponse>;
     create(data: CaseTicketData): Promise<CaseTicketResponse>;
     update(caseTicketId: NonEmptyString<string>, data: Partial<CaseTicketData>): Promise<CaseTicketResponse>;
@@ -82,6 +96,7 @@ export default class CasesTickets {
     resolve(caseTicketId: NonEmptyString<string>, resolutionNotes: string): Promise<CaseTicketResponse>;
     assign(caseTicketId: NonEmptyString<string>, agentId: NonEmptyString<string>): Promise<CaseTicketResponse>;
     addNote(caseTicketId: NonEmptyString<string>, note: string): Promise<CaseTicketResponse>;
+    listNotes(caseTicketId: NonEmptyString<string>): Promise<string[]>;
     escalate(caseTicketId: NonEmptyString<string>, level: EscalationLevel): Promise<CaseTicketResponse>;
     close(caseTicketId: NonEmptyString<string>): Promise<CaseTicketResponse>;
     reopen(caseTicketId: NonEmptyString<string>, note: string): Promise<CaseTicketResponse>;

--- a/dist/lib/resources/CaseTicket.js
+++ b/dist/lib/resources/CaseTicket.js
@@ -119,6 +119,33 @@ class CasesTickets {
             throw this.handleError(error, 'list');
         }
     }
+    async search(query, params = {}) {
+        const queryParams = new URLSearchParams({ query });
+        if (params.status)
+            queryParams.append('status', params.status);
+        if (params.priority)
+            queryParams.append('priority', params.priority);
+        if (params.org_id)
+            queryParams.append('org_id', params.org_id);
+        if (params.limit)
+            queryParams.append('limit', params.limit.toString());
+        if (params.offset)
+            queryParams.append('offset', params.offset.toString());
+        try {
+            const response = await this.stateset.request('GET', `cases_tickets/search?${queryParams.toString()}`);
+            return {
+                cases_tickets: response.cases_tickets.map(this.mapResponse),
+                pagination: {
+                    total: response.total || response.cases_tickets.length,
+                    limit: params.limit || 100,
+                    offset: params.offset || 0,
+                },
+            };
+        }
+        catch (error) {
+            throw this.handleError(error, 'search');
+        }
+    }
     async get(caseTicketId) {
         try {
             const response = await this.stateset.request('GET', `cases_tickets/${caseTicketId}`);
@@ -180,6 +207,15 @@ class CasesTickets {
         }
         catch (error) {
             throw this.handleError(error, 'addNote', caseTicketId);
+        }
+    }
+    async listNotes(caseTicketId) {
+        try {
+            const response = await this.stateset.request('GET', `cases_tickets/${caseTicketId}/notes`);
+            return response.notes || [];
+        }
+        catch (error) {
+            throw this.handleError(error, 'listNotes', caseTicketId);
         }
     }
     async escalate(caseTicketId, level) {

--- a/src/lib/resources/CaseTicket.ts
+++ b/src/lib/resources/CaseTicket.ts
@@ -147,6 +147,44 @@ export default class CasesTickets {
     }
   }
 
+  async search(
+    query: string,
+    params: {
+      status?: CaseTicketStatus;
+      priority?: CaseTicketPriority;
+      org_id?: string;
+      limit?: number;
+      offset?: number;
+    } = {}
+  ): Promise<{
+    cases_tickets: CaseTicketResponse[];
+    pagination: { total: number; limit: number; offset: number };
+  }> {
+    const queryParams = new URLSearchParams({ query });
+    if (params.status) queryParams.append('status', params.status);
+    if (params.priority) queryParams.append('priority', params.priority);
+    if (params.org_id) queryParams.append('org_id', params.org_id);
+    if (params.limit) queryParams.append('limit', params.limit.toString());
+    if (params.offset) queryParams.append('offset', params.offset.toString());
+
+    try {
+      const response = await this.stateset.request(
+        'GET',
+        `cases_tickets/search?${queryParams.toString()}`
+      );
+      return {
+        cases_tickets: response.cases_tickets.map(this.mapResponse),
+        pagination: {
+          total: response.total || response.cases_tickets.length,
+          limit: params.limit || 100,
+          offset: params.offset || 0,
+        },
+      };
+    } catch (error: any) {
+      throw this.handleError(error, 'search');
+    }
+  }
+
   async get(caseTicketId: NonEmptyString<string>): Promise<CaseTicketResponse> {
     try {
       const response = await this.stateset.request('GET', `cases_tickets/${caseTicketId}`);
@@ -207,6 +245,15 @@ export default class CasesTickets {
       return this.mapResponse(response.case_ticket);
     } catch (error: any) {
       throw this.handleError(error, 'addNote', caseTicketId);
+    }
+  }
+
+  async listNotes(caseTicketId: NonEmptyString<string>): Promise<string[]> {
+    try {
+      const response = await this.stateset.request('GET', `cases_tickets/${caseTicketId}/notes`);
+      return response.notes || [];
+    } catch (error: any) {
+      throw this.handleError(error, 'listNotes', caseTicketId);
     }
   }
 


### PR DESCRIPTION
## Summary
- extend `CaseTicket` resource with `search` and `listNotes` helpers
- document new methods in README
- test for presence of new helpers
- rebuild dist output

## Testing
- `npm run build`
- `npm test`
