### PR TITLE
Add OpenAI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The SDK exposes helper classes for building intelligent agents. These include:
 - **Attributes** describing agent skills or traits.
 - **Knowledge** base entries for retrieval.
 - **Evals** to record evaluation metrics.
+- **OpenAIIntegration** for generating chat completions.
 
 ## Usage example
 
@@ -113,6 +114,18 @@ console.log(searchResults.cases_tickets);
 
 const notes = await client.casesTickets.listNotes(ticket.id);
 console.log(notes);
+```
+
+### Generating responses with OpenAI
+
+```javascript
+import { OpenAIIntegration } from 'stateset-node';
+
+const openai = new OpenAIIntegration(process.env.OPENAI_API_KEY || 'sk-test');
+const completion = await openai.createChatCompletion([
+  { role: 'user', content: 'Where is my order?' }
+]);
+console.log(completion.choices[0].message.content);
 ```
 
 ### Managing orders

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,4 +1,5 @@
 import stateset from '../src';
+import { OpenAIIntegration } from '../src';
 
 test('exports stateset class', () => {
   expect(typeof stateset).toBe('function');
@@ -62,4 +63,24 @@ test('exposes customer service helper methods', () => {
   expect(typeof client.casesTickets.listNotes).toBe('function');
   expect(typeof client.orders.addNote).toBe('function');
   expect(typeof client.orders.listNotes).toBe('function');
+});
+
+test('OpenAIIntegration sends chat completion request', async () => {
+  const integration: any = new OpenAIIntegration('test-key', 'https://example.com');
+  const mockPost = jest
+    .spyOn(integration.client, 'post')
+    .mockResolvedValue({
+      data: {
+        choices: [
+          { index: 0, message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }
+        ]
+      }
+    });
+
+  const res = await integration.createChatCompletion([
+    { role: 'user', content: 'hello' }
+  ]);
+
+  expect(mockPost).toHaveBeenCalledWith('/chat/completions', expect.any(Object));
+  expect(res.choices[0].message.content).toBe('hi');
 });

--- a/dist/lib/integrations/OpenAIIntegration.d.ts
+++ b/dist/lib/integrations/OpenAIIntegration.d.ts
@@ -1,0 +1,26 @@
+export interface ChatMessage {
+    role: 'system' | 'user' | 'assistant';
+    content: string;
+}
+export interface ChatCompletionOptions {
+    model?: string;
+    temperature?: number;
+    max_tokens?: number;
+}
+export interface ChatCompletionResponseChoice {
+    index: number;
+    message: ChatMessage;
+    finish_reason: string;
+}
+export interface ChatCompletionResponse {
+    id: string;
+    object: string;
+    created: number;
+    model: string;
+    choices: ChatCompletionResponseChoice[];
+}
+export default class OpenAIIntegration {
+    private client;
+    constructor(apiKey: string, baseUrl?: string);
+    createChatCompletion(messages: ChatMessage[], options?: ChatCompletionOptions): Promise<ChatCompletionResponse>;
+}

--- a/dist/lib/integrations/OpenAIIntegration.js
+++ b/dist/lib/integrations/OpenAIIntegration.js
@@ -1,0 +1,27 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const axios_1 = __importDefault(require("axios"));
+class OpenAIIntegration {
+    constructor(apiKey, baseUrl = 'https://api.openai.com/v1') {
+        this.client = axios_1.default.create({
+            baseURL: baseUrl,
+            headers: {
+                Authorization: `Bearer ${apiKey}`,
+                'Content-Type': 'application/json'
+            }
+        });
+    }
+    async createChatCompletion(messages, options = {}) {
+        const data = {
+            model: options.model || 'gpt-3.5-turbo',
+            messages,
+            ...options
+        };
+        const resp = await this.client.post('/chat/completions', data);
+        return resp.data;
+    }
+}
+exports.default = OpenAIIntegration;

--- a/dist/lib/resources/Carrier.d.ts
+++ b/dist/lib/resources/Carrier.d.ts
@@ -1,0 +1,79 @@
+import { stateset } from '../../stateset-client';
+type NonEmptyString<T extends string> = T extends '' ? never : T;
+type Timestamp = string;
+export declare enum CarrierStatus {
+    ACTIVE = "ACTIVE",
+    INACTIVE = "INACTIVE",
+    SUSPENDED = "SUSPENDED"
+}
+export declare enum CarrierType {
+    FREIGHT = "FREIGHT",
+    PARCEL = "PARCEL",
+    COURIER = "COURIER"
+}
+export interface CarrierData {
+    name: NonEmptyString<string>;
+    carrier_code: NonEmptyString<string>;
+    status: CarrierStatus;
+    type: CarrierType;
+    contact_email?: string;
+    contact_phone?: string;
+    rates: Array<{
+        service_code: string;
+        service_name: string;
+        base_rate: number;
+        currency: string;
+    }>;
+    performance?: {
+        on_time_delivery_rate: number;
+        average_transit_time: number;
+        total_shipments: number;
+    };
+    created_at: Timestamp;
+    updated_at: Timestamp;
+    org_id?: string;
+    metadata?: Record<string, any>;
+}
+export interface CarrierResponse {
+    id: NonEmptyString<string>;
+    object: 'carrier';
+    data: CarrierData;
+}
+export declare class CarrierError extends Error {
+    readonly details?: Record<string, unknown> | undefined;
+    constructor(message: string, details?: Record<string, unknown> | undefined);
+}
+export declare class CarrierNotFoundError extends CarrierError {
+    constructor(carrierId: string);
+}
+export declare class CarrierValidationError extends CarrierError {
+    readonly errors?: Record<string, string> | undefined;
+    constructor(message: string, errors?: Record<string, string> | undefined);
+}
+export default class Carriers {
+    private readonly stateset;
+    constructor(stateset: stateset);
+    private validateCarrierData;
+    private mapResponse;
+    list(params?: {
+        status?: CarrierStatus;
+        type?: CarrierType;
+        org_id?: string;
+        limit?: number;
+        offset?: number;
+    }): Promise<{
+        carriers: CarrierResponse[];
+        pagination: {
+            total: number;
+            limit: number;
+            offset: number;
+        };
+    }>;
+    get(carrierId: NonEmptyString<string>): Promise<CarrierResponse>;
+    create(data: CarrierData): Promise<CarrierResponse>;
+    update(carrierId: NonEmptyString<string>, data: Partial<CarrierData>): Promise<CarrierResponse>;
+    delete(carrierId: NonEmptyString<string>): Promise<void>;
+    updatePerformance(carrierId: NonEmptyString<string>, performance: CarrierData['performance']): Promise<CarrierResponse>;
+    private handleError;
+}
+export {};

--- a/dist/lib/resources/Carrier.js
+++ b/dist/lib/resources/Carrier.js
@@ -1,0 +1,157 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.CarrierValidationError = exports.CarrierNotFoundError = exports.CarrierError = exports.CarrierType = exports.CarrierStatus = void 0;
+// Enums
+var CarrierStatus;
+(function (CarrierStatus) {
+    CarrierStatus["ACTIVE"] = "ACTIVE";
+    CarrierStatus["INACTIVE"] = "INACTIVE";
+    CarrierStatus["SUSPENDED"] = "SUSPENDED";
+})(CarrierStatus = exports.CarrierStatus || (exports.CarrierStatus = {}));
+var CarrierType;
+(function (CarrierType) {
+    CarrierType["FREIGHT"] = "FREIGHT";
+    CarrierType["PARCEL"] = "PARCEL";
+    CarrierType["COURIER"] = "COURIER";
+})(CarrierType = exports.CarrierType || (exports.CarrierType = {}));
+// Error Classes
+class CarrierError extends Error {
+    constructor(message, details) {
+        super(message);
+        this.details = details;
+        this.name = 'CarrierError';
+    }
+}
+exports.CarrierError = CarrierError;
+class CarrierNotFoundError extends CarrierError {
+    constructor(carrierId) {
+        super(`Carrier with ID ${carrierId} not found`, { carrierId });
+    }
+}
+exports.CarrierNotFoundError = CarrierNotFoundError;
+class CarrierValidationError extends CarrierError {
+    constructor(message, errors) {
+        super(message);
+        this.errors = errors;
+    }
+}
+exports.CarrierValidationError = CarrierValidationError;
+class Carriers {
+    constructor(stateset) {
+        this.stateset = stateset;
+    }
+    validateCarrierData(data) {
+        var _a;
+        if (!data.name)
+            throw new CarrierValidationError('Carrier name is required');
+        if (!data.carrier_code)
+            throw new CarrierValidationError('Carrier code is required');
+        if ((_a = data.rates) === null || _a === void 0 ? void 0 : _a.some(rate => rate.base_rate < 0)) {
+            throw new CarrierValidationError('Base rate cannot be negative');
+        }
+    }
+    mapResponse(data) {
+        if (!(data === null || data === void 0 ? void 0 : data.id))
+            throw new CarrierError('Invalid response format');
+        return {
+            id: data.id,
+            object: 'carrier',
+            data: {
+                name: data.name,
+                carrier_code: data.carrier_code,
+                status: data.status,
+                type: data.type,
+                contact_email: data.contact_email,
+                contact_phone: data.contact_phone,
+                rates: data.rates,
+                performance: data.performance,
+                created_at: data.created_at,
+                updated_at: data.updated_at,
+                org_id: data.org_id,
+                metadata: data.metadata,
+            },
+        };
+    }
+    async list(params) {
+        const queryParams = new URLSearchParams();
+        if (params) {
+            if (params.status)
+                queryParams.append('status', params.status);
+            if (params.type)
+                queryParams.append('type', params.type);
+            if (params.org_id)
+                queryParams.append('org_id', params.org_id);
+            if (params.limit)
+                queryParams.append('limit', params.limit.toString());
+            if (params.offset)
+                queryParams.append('offset', params.offset.toString());
+        }
+        try {
+            const response = await this.stateset.request('GET', `carriers?${queryParams.toString()}`);
+            return {
+                carriers: response.carriers.map(this.mapResponse),
+                pagination: {
+                    total: response.total || response.carriers.length,
+                    limit: (params === null || params === void 0 ? void 0 : params.limit) || 100,
+                    offset: (params === null || params === void 0 ? void 0 : params.offset) || 0,
+                },
+            };
+        }
+        catch (error) {
+            throw this.handleError(error, 'list');
+        }
+    }
+    async get(carrierId) {
+        try {
+            const response = await this.stateset.request('GET', `carriers/${carrierId}`);
+            return this.mapResponse(response.carrier);
+        }
+        catch (error) {
+            throw this.handleError(error, 'get', carrierId);
+        }
+    }
+    async create(data) {
+        this.validateCarrierData(data);
+        try {
+            const response = await this.stateset.request('POST', 'carriers', data);
+            return this.mapResponse(response.carrier);
+        }
+        catch (error) {
+            throw this.handleError(error, 'create');
+        }
+    }
+    async update(carrierId, data) {
+        try {
+            const response = await this.stateset.request('PUT', `carriers/${carrierId}`, data);
+            return this.mapResponse(response.carrier);
+        }
+        catch (error) {
+            throw this.handleError(error, 'update', carrierId);
+        }
+    }
+    async delete(carrierId) {
+        try {
+            await this.stateset.request('DELETE', `carriers/${carrierId}`);
+        }
+        catch (error) {
+            throw this.handleError(error, 'delete', carrierId);
+        }
+    }
+    async updatePerformance(carrierId, performance) {
+        try {
+            const response = await this.stateset.request('POST', `carriers/${carrierId}/performance`, { performance });
+            return this.mapResponse(response.carrier);
+        }
+        catch (error) {
+            throw this.handleError(error, 'updatePerformance', carrierId);
+        }
+    }
+    handleError(error, operation, carrierId) {
+        if (error.status === 404)
+            throw new CarrierNotFoundError(carrierId || 'unknown');
+        if (error.status === 400)
+            throw new CarrierValidationError(error.message, error.errors);
+        throw new CarrierError(`Failed to ${operation} carrier: ${error.message}`, { operation, originalError: error });
+    }
+}
+exports.default = Carriers;

--- a/dist/lib/resources/CreditsDebits.d.ts
+++ b/dist/lib/resources/CreditsDebits.d.ts
@@ -1,0 +1,76 @@
+import { stateset } from '../../stateset-client';
+type NonEmptyString<T extends string> = T extends '' ? never : T;
+type Timestamp = string;
+export declare enum CreditDebitType {
+    CREDIT = "CREDIT",
+    DEBIT = "DEBIT"
+}
+export declare enum CreditDebitStatus {
+    PENDING = "PENDING",
+    APPLIED = "APPLIED",
+    EXPIRED = "EXPIRED",
+    CANCELLED = "CANCELLED"
+}
+export interface CreditsDebitsData {
+    customer_id: NonEmptyString<string>;
+    type: CreditDebitType;
+    status: CreditDebitStatus;
+    amount: number;
+    currency: string;
+    reason: string;
+    issued_date: Timestamp;
+    expiry_date?: Timestamp;
+    applied_date?: Timestamp;
+    order_id?: NonEmptyString<string>;
+    notes?: string[];
+    created_at: Timestamp;
+    updated_at: Timestamp;
+    org_id?: string;
+    metadata?: Record<string, any>;
+}
+export interface CreditsDebitsResponse {
+    id: NonEmptyString<string>;
+    object: 'credit_debit';
+    data: CreditsDebitsData;
+}
+export declare class CreditsDebitsError extends Error {
+    readonly details?: Record<string, unknown> | undefined;
+    constructor(message: string, details?: Record<string, unknown> | undefined);
+}
+export declare class CreditsDebitsNotFoundError extends CreditsDebitsError {
+    constructor(creditsDebitsId: string);
+}
+export declare class CreditsDebitsValidationError extends CreditsDebitsError {
+    readonly errors?: Record<string, string> | undefined;
+    constructor(message: string, errors?: Record<string, string> | undefined);
+}
+export default class CreditsDebits {
+    private readonly stateset;
+    constructor(stateset: stateset);
+    private validateCreditsDebitsData;
+    private mapResponse;
+    list(params?: {
+        customer_id?: string;
+        type?: CreditDebitType;
+        status?: CreditDebitStatus;
+        org_id?: string;
+        date_from?: Date;
+        date_to?: Date;
+        limit?: number;
+        offset?: number;
+    }): Promise<{
+        credits_debits: CreditsDebitsResponse[];
+        pagination: {
+            total: number;
+            limit: number;
+            offset: number;
+        };
+    }>;
+    get(creditsDebitsId: NonEmptyString<string>): Promise<CreditsDebitsResponse>;
+    create(data: CreditsDebitsData): Promise<CreditsDebitsResponse>;
+    update(creditsDebitsId: NonEmptyString<string>, data: Partial<CreditsDebitsData>): Promise<CreditsDebitsResponse>;
+    delete(creditsDebitsId: NonEmptyString<string>): Promise<void>;
+    applyCreditDebit(creditsDebitsId: NonEmptyString<string>, appliedDate: Timestamp): Promise<CreditsDebitsResponse>;
+    private handleError;
+}
+export {};

--- a/dist/lib/resources/CreditsDebits.js
+++ b/dist/lib/resources/CreditsDebits.js
@@ -1,0 +1,164 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.CreditsDebitsValidationError = exports.CreditsDebitsNotFoundError = exports.CreditsDebitsError = exports.CreditDebitStatus = exports.CreditDebitType = void 0;
+// Enums
+var CreditDebitType;
+(function (CreditDebitType) {
+    CreditDebitType["CREDIT"] = "CREDIT";
+    CreditDebitType["DEBIT"] = "DEBIT";
+})(CreditDebitType = exports.CreditDebitType || (exports.CreditDebitType = {}));
+var CreditDebitStatus;
+(function (CreditDebitStatus) {
+    CreditDebitStatus["PENDING"] = "PENDING";
+    CreditDebitStatus["APPLIED"] = "APPLIED";
+    CreditDebitStatus["EXPIRED"] = "EXPIRED";
+    CreditDebitStatus["CANCELLED"] = "CANCELLED";
+})(CreditDebitStatus = exports.CreditDebitStatus || (exports.CreditDebitStatus = {}));
+// Error Classes
+class CreditsDebitsError extends Error {
+    constructor(message, details) {
+        super(message);
+        this.details = details;
+        this.name = 'CreditsDebitsError';
+    }
+}
+exports.CreditsDebitsError = CreditsDebitsError;
+class CreditsDebitsNotFoundError extends CreditsDebitsError {
+    constructor(creditsDebitsId) {
+        super(`Credit/Debit with ID ${creditsDebitsId} not found`, { creditsDebitsId });
+    }
+}
+exports.CreditsDebitsNotFoundError = CreditsDebitsNotFoundError;
+class CreditsDebitsValidationError extends CreditsDebitsError {
+    constructor(message, errors) {
+        super(message);
+        this.errors = errors;
+    }
+}
+exports.CreditsDebitsValidationError = CreditsDebitsValidationError;
+class CreditsDebits {
+    constructor(stateset) {
+        this.stateset = stateset;
+    }
+    validateCreditsDebitsData(data) {
+        if (!data.customer_id)
+            throw new CreditsDebitsValidationError('Customer ID is required');
+        if (data.amount <= 0)
+            throw new CreditsDebitsValidationError('Amount must be greater than 0');
+        if (!data.issued_date)
+            throw new CreditsDebitsValidationError('Issued date is required');
+    }
+    mapResponse(data) {
+        if (!(data === null || data === void 0 ? void 0 : data.id))
+            throw new CreditsDebitsError('Invalid response format');
+        return {
+            id: data.id,
+            object: 'credit_debit',
+            data: {
+                customer_id: data.customer_id,
+                type: data.type,
+                status: data.status,
+                amount: data.amount,
+                currency: data.currency,
+                reason: data.reason,
+                issued_date: data.issued_date,
+                expiry_date: data.expiry_date,
+                applied_date: data.applied_date,
+                order_id: data.order_id,
+                notes: data.notes,
+                created_at: data.created_at,
+                updated_at: data.updated_at,
+                org_id: data.org_id,
+                metadata: data.metadata,
+            },
+        };
+    }
+    async list(params) {
+        const queryParams = new URLSearchParams();
+        if (params) {
+            if (params.customer_id)
+                queryParams.append('customer_id', params.customer_id);
+            if (params.type)
+                queryParams.append('type', params.type);
+            if (params.status)
+                queryParams.append('status', params.status);
+            if (params.org_id)
+                queryParams.append('org_id', params.org_id);
+            if (params.date_from)
+                queryParams.append('date_from', params.date_from.toISOString());
+            if (params.date_to)
+                queryParams.append('date_to', params.date_to.toISOString());
+            if (params.limit)
+                queryParams.append('limit', params.limit.toString());
+            if (params.offset)
+                queryParams.append('offset', params.offset.toString());
+        }
+        try {
+            const response = await this.stateset.request('GET', `credits_debits?${queryParams.toString()}`);
+            return {
+                credits_debits: response.credits_debits.map(this.mapResponse),
+                pagination: {
+                    total: response.total || response.credits_debits.length,
+                    limit: (params === null || params === void 0 ? void 0 : params.limit) || 100,
+                    offset: (params === null || params === void 0 ? void 0 : params.offset) || 0,
+                },
+            };
+        }
+        catch (error) {
+            throw this.handleError(error, 'list');
+        }
+    }
+    async get(creditsDebitsId) {
+        try {
+            const response = await this.stateset.request('GET', `credits_debits/${creditsDebitsId}`);
+            return this.mapResponse(response.credit_debit);
+        }
+        catch (error) {
+            throw this.handleError(error, 'get', creditsDebitsId);
+        }
+    }
+    async create(data) {
+        this.validateCreditsDebitsData(data);
+        try {
+            const response = await this.stateset.request('POST', 'credits_debits', data);
+            return this.mapResponse(response.credit_debit);
+        }
+        catch (error) {
+            throw this.handleError(error, 'create');
+        }
+    }
+    async update(creditsDebitsId, data) {
+        try {
+            const response = await this.stateset.request('PUT', `credits_debits/${creditsDebitsId}`, data);
+            return this.mapResponse(response.credit_debit);
+        }
+        catch (error) {
+            throw this.handleError(error, 'update', creditsDebitsId);
+        }
+    }
+    async delete(creditsDebitsId) {
+        try {
+            await this.stateset.request('DELETE', `credits_debits/${creditsDebitsId}`);
+        }
+        catch (error) {
+            throw this.handleError(error, 'delete', creditsDebitsId);
+        }
+    }
+    async applyCreditDebit(creditsDebitsId, appliedDate) {
+        try {
+            const response = await this.stateset.request('POST', `credits_debits/${creditsDebitsId}/apply`, { applied_date: appliedDate });
+            return this.mapResponse(response.credit_debit);
+        }
+        catch (error) {
+            throw this.handleError(error, 'applyCreditDebit', creditsDebitsId);
+        }
+    }
+    handleError(error, operation, creditsDebitsId) {
+        if (error.status === 404)
+            throw new CreditsDebitsNotFoundError(creditsDebitsId || 'unknown');
+        if (error.status === 400)
+            throw new CreditsDebitsValidationError(error.message, error.errors);
+        throw new CreditsDebitsError(`Failed to ${operation} credit/debit: ${error.message}`, { operation, originalError: error });
+    }
+}
+exports.default = CreditsDebits;

--- a/dist/lib/resources/DeliveryConfirmation.d.ts
+++ b/dist/lib/resources/DeliveryConfirmation.d.ts
@@ -1,0 +1,73 @@
+import { stateset } from '../../stateset-client';
+type NonEmptyString<T extends string> = T extends '' ? never : T;
+type Timestamp = string;
+export declare enum DeliveryConfirmationStatus {
+    PENDING = "PENDING",
+    CONFIRMED = "CONFIRMED",
+    DISPUTED = "DISPUTED",
+    FAILED = "FAILED"
+}
+export interface DeliveryConfirmationData {
+    shipment_id: NonEmptyString<string>;
+    status: DeliveryConfirmationStatus;
+    delivery_date: Timestamp;
+    recipient_name?: string;
+    proof_of_delivery?: {
+        signature_url?: string;
+        photo_url?: string;
+        notes?: string;
+    };
+    confirmed_by?: NonEmptyString<string>;
+    created_at: Timestamp;
+    updated_at: Timestamp;
+    org_id?: string;
+    metadata?: Record<string, any>;
+}
+export interface DeliveryConfirmationResponse {
+    id: NonEmptyString<string>;
+    object: 'delivery_confirmation';
+    data: DeliveryConfirmationData;
+}
+export declare class DeliveryConfirmationError extends Error {
+    readonly details?: Record<string, unknown> | undefined;
+    constructor(message: string, details?: Record<string, unknown> | undefined);
+}
+export declare class DeliveryConfirmationNotFoundError extends DeliveryConfirmationError {
+    constructor(deliveryConfirmationId: string);
+}
+export declare class DeliveryConfirmationValidationError extends DeliveryConfirmationError {
+    readonly errors?: Record<string, string> | undefined;
+    constructor(message: string, errors?: Record<string, string> | undefined);
+}
+export default class DeliveryConfirmations {
+    private readonly stateset;
+    constructor(stateset: stateset);
+    private validateDeliveryConfirmationData;
+    private mapResponse;
+    list(params?: {
+        shipment_id?: string;
+        status?: DeliveryConfirmationStatus;
+        org_id?: string;
+        date_from?: Date;
+        date_to?: Date;
+        limit?: number;
+        offset?: number;
+    }): Promise<{
+        delivery_confirmations: DeliveryConfirmationResponse[];
+        pagination: {
+            total: number;
+            limit: number;
+            offset: number;
+        };
+    }>;
+    get(deliveryConfirmationId: NonEmptyString<string>): Promise<DeliveryConfirmationResponse>;
+    create(data: DeliveryConfirmationData): Promise<DeliveryConfirmationResponse>;
+    update(deliveryConfirmationId: NonEmptyString<string>, data: Partial<DeliveryConfirmationData>): Promise<DeliveryConfirmationResponse>;
+    delete(deliveryConfirmationId: NonEmptyString<string>): Promise<void>;
+    confirmDelivery(deliveryConfirmationId: NonEmptyString<string>, confirmationData: {
+        recipient_name: string;
+        proof_of_delivery: DeliveryConfirmationData['proof_of_delivery'];
+    }): Promise<DeliveryConfirmationResponse>;
+    private handleError;
+}
+export {};

--- a/dist/lib/resources/DeliveryConfirmation.js
+++ b/dist/lib/resources/DeliveryConfirmation.js
@@ -1,0 +1,150 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.DeliveryConfirmationValidationError = exports.DeliveryConfirmationNotFoundError = exports.DeliveryConfirmationError = exports.DeliveryConfirmationStatus = void 0;
+// Enums
+var DeliveryConfirmationStatus;
+(function (DeliveryConfirmationStatus) {
+    DeliveryConfirmationStatus["PENDING"] = "PENDING";
+    DeliveryConfirmationStatus["CONFIRMED"] = "CONFIRMED";
+    DeliveryConfirmationStatus["DISPUTED"] = "DISPUTED";
+    DeliveryConfirmationStatus["FAILED"] = "FAILED";
+})(DeliveryConfirmationStatus = exports.DeliveryConfirmationStatus || (exports.DeliveryConfirmationStatus = {}));
+// Error Classes
+class DeliveryConfirmationError extends Error {
+    constructor(message, details) {
+        super(message);
+        this.details = details;
+        this.name = 'DeliveryConfirmationError';
+    }
+}
+exports.DeliveryConfirmationError = DeliveryConfirmationError;
+class DeliveryConfirmationNotFoundError extends DeliveryConfirmationError {
+    constructor(deliveryConfirmationId) {
+        super(`Delivery confirmation with ID ${deliveryConfirmationId} not found`, { deliveryConfirmationId });
+    }
+}
+exports.DeliveryConfirmationNotFoundError = DeliveryConfirmationNotFoundError;
+class DeliveryConfirmationValidationError extends DeliveryConfirmationError {
+    constructor(message, errors) {
+        super(message);
+        this.errors = errors;
+    }
+}
+exports.DeliveryConfirmationValidationError = DeliveryConfirmationValidationError;
+class DeliveryConfirmations {
+    constructor(stateset) {
+        this.stateset = stateset;
+    }
+    validateDeliveryConfirmationData(data) {
+        if (!data.shipment_id)
+            throw new DeliveryConfirmationValidationError('Shipment ID is required');
+        if (!data.delivery_date)
+            throw new DeliveryConfirmationValidationError('Delivery date is required');
+    }
+    mapResponse(data) {
+        if (!(data === null || data === void 0 ? void 0 : data.id))
+            throw new DeliveryConfirmationError('Invalid response format');
+        return {
+            id: data.id,
+            object: 'delivery_confirmation',
+            data: {
+                shipment_id: data.shipment_id,
+                status: data.status,
+                delivery_date: data.delivery_date,
+                recipient_name: data.recipient_name,
+                proof_of_delivery: data.proof_of_delivery,
+                confirmed_by: data.confirmed_by,
+                created_at: data.created_at,
+                updated_at: data.updated_at,
+                org_id: data.org_id,
+                metadata: data.metadata,
+            },
+        };
+    }
+    async list(params) {
+        const queryParams = new URLSearchParams();
+        if (params) {
+            if (params.shipment_id)
+                queryParams.append('shipment_id', params.shipment_id);
+            if (params.status)
+                queryParams.append('status', params.status);
+            if (params.org_id)
+                queryParams.append('org_id', params.org_id);
+            if (params.date_from)
+                queryParams.append('date_from', params.date_from.toISOString());
+            if (params.date_to)
+                queryParams.append('date_to', params.date_to.toISOString());
+            if (params.limit)
+                queryParams.append('limit', params.limit.toString());
+            if (params.offset)
+                queryParams.append('offset', params.offset.toString());
+        }
+        try {
+            const response = await this.stateset.request('GET', `delivery_confirmations?${queryParams.toString()}`);
+            return {
+                delivery_confirmations: response.delivery_confirmations.map(this.mapResponse),
+                pagination: {
+                    total: response.total || response.delivery_confirmations.length,
+                    limit: (params === null || params === void 0 ? void 0 : params.limit) || 100,
+                    offset: (params === null || params === void 0 ? void 0 : params.offset) || 0,
+                },
+            };
+        }
+        catch (error) {
+            throw this.handleError(error, 'list');
+        }
+    }
+    async get(deliveryConfirmationId) {
+        try {
+            const response = await this.stateset.request('GET', `delivery_confirmations/${deliveryConfirmationId}`);
+            return this.mapResponse(response.delivery_confirmation);
+        }
+        catch (error) {
+            throw this.handleError(error, 'get', deliveryConfirmationId);
+        }
+    }
+    async create(data) {
+        this.validateDeliveryConfirmationData(data);
+        try {
+            const response = await this.stateset.request('POST', 'delivery_confirmations', data);
+            return this.mapResponse(response.delivery_confirmation);
+        }
+        catch (error) {
+            throw this.handleError(error, 'create');
+        }
+    }
+    async update(deliveryConfirmationId, data) {
+        try {
+            const response = await this.stateset.request('PUT', `delivery_confirmations/${deliveryConfirmationId}`, data);
+            return this.mapResponse(response.delivery_confirmation);
+        }
+        catch (error) {
+            throw this.handleError(error, 'update', deliveryConfirmationId);
+        }
+    }
+    async delete(deliveryConfirmationId) {
+        try {
+            await this.stateset.request('DELETE', `delivery_confirmations/${deliveryConfirmationId}`);
+        }
+        catch (error) {
+            throw this.handleError(error, 'delete', deliveryConfirmationId);
+        }
+    }
+    async confirmDelivery(deliveryConfirmationId, confirmationData) {
+        try {
+            const response = await this.stateset.request('POST', `delivery_confirmations/${deliveryConfirmationId}/confirm`, confirmationData);
+            return this.mapResponse(response.delivery_confirmation);
+        }
+        catch (error) {
+            throw this.handleError(error, 'confirmDelivery', deliveryConfirmationId);
+        }
+    }
+    handleError(error, operation, deliveryConfirmationId) {
+        if (error.status === 404)
+            throw new DeliveryConfirmationNotFoundError(deliveryConfirmationId || 'unknown');
+        if (error.status === 400)
+            throw new DeliveryConfirmationValidationError(error.message, error.errors);
+        throw new DeliveryConfirmationError(`Failed to ${operation} delivery confirmation: ${error.message}`, { operation, originalError: error });
+    }
+}
+exports.default = DeliveryConfirmations;

--- a/dist/lib/resources/Eval.d.ts
+++ b/dist/lib/resources/Eval.d.ts
@@ -1,0 +1,58 @@
+import { stateset } from '../../stateset-client';
+export declare enum EvalType {
+    AGENT = "agent",
+    RESPONSE = "response",
+    RULE = "rule",
+    ATTRIBUTE = "attribute"
+}
+export interface EvalMetric {
+    name: string;
+    value: number;
+    metadata?: Record<string, any>;
+}
+export interface EvalData {
+    eval_type: EvalType;
+    subject_id: string;
+    metrics: EvalMetric[];
+    summary?: string;
+    agent_id?: string;
+    org_id?: string;
+    user_id?: string;
+}
+export interface EvalRecord {
+    id: string;
+    created_at: string;
+    data: EvalData;
+}
+export declare class EvalNotFoundError extends Error {
+    constructor(evalId: string);
+}
+export declare class EvalValidationError extends Error {
+    constructor(message: string);
+}
+declare class Evals {
+    private readonly stateset;
+    constructor(stateset: stateset);
+    /**
+     * List evaluations with optional filtering
+     */
+    list(params?: {
+        eval_type?: EvalType;
+        subject_id?: string;
+        agent_id?: string;
+        org_id?: string;
+    }): Promise<EvalRecord[]>;
+    /**
+     * Get a specific evaluation
+     */
+    get(evalId: string): Promise<EvalRecord>;
+    /**
+     * Create evaluation
+     */
+    create(data: EvalData): Promise<EvalRecord>;
+    /**
+     * Delete evaluation
+     */
+    delete(evalId: string): Promise<void>;
+}
+export default Evals;

--- a/dist/lib/resources/Eval.js
+++ b/dist/lib/resources/Eval.js
@@ -1,0 +1,89 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.EvalValidationError = exports.EvalNotFoundError = exports.EvalType = void 0;
+// Enums for evaluation management
+var EvalType;
+(function (EvalType) {
+    EvalType["AGENT"] = "agent";
+    EvalType["RESPONSE"] = "response";
+    EvalType["RULE"] = "rule";
+    EvalType["ATTRIBUTE"] = "attribute";
+})(EvalType = exports.EvalType || (exports.EvalType = {}));
+class EvalNotFoundError extends Error {
+    constructor(evalId) {
+        super(`Eval with ID ${evalId} not found`);
+        this.name = 'EvalNotFoundError';
+    }
+}
+exports.EvalNotFoundError = EvalNotFoundError;
+class EvalValidationError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'EvalValidationError';
+    }
+}
+exports.EvalValidationError = EvalValidationError;
+class Evals {
+    constructor(stateset) {
+        this.stateset = stateset;
+    }
+    /**
+     * List evaluations with optional filtering
+     */
+    async list(params) {
+        const queryParams = new URLSearchParams();
+        if (params === null || params === void 0 ? void 0 : params.eval_type)
+            queryParams.append('eval_type', params.eval_type);
+        if (params === null || params === void 0 ? void 0 : params.subject_id)
+            queryParams.append('subject_id', params.subject_id);
+        if (params === null || params === void 0 ? void 0 : params.agent_id)
+            queryParams.append('agent_id', params.agent_id);
+        if (params === null || params === void 0 ? void 0 : params.org_id)
+            queryParams.append('org_id', params.org_id);
+        const response = await this.stateset.request('GET', `evals?${queryParams.toString()}`);
+        return response.evals;
+    }
+    /**
+     * Get a specific evaluation
+     */
+    async get(evalId) {
+        try {
+            const response = await this.stateset.request('GET', `evals/${evalId}`);
+            return response.eval;
+        }
+        catch (error) {
+            if (error.status === 404) {
+                throw new EvalNotFoundError(evalId);
+            }
+            throw error;
+        }
+    }
+    /**
+     * Create evaluation
+     */
+    async create(data) {
+        if (!data.subject_id) {
+            throw new EvalValidationError('subject_id is required');
+        }
+        if (!data.metrics || data.metrics.length === 0) {
+            throw new EvalValidationError('at least one metric is required');
+        }
+        const response = await this.stateset.request('POST', 'evals', data);
+        return response.eval;
+    }
+    /**
+     * Delete evaluation
+     */
+    async delete(evalId) {
+        try {
+            await this.stateset.request('DELETE', `evals/${evalId}`);
+        }
+        catch (error) {
+            if (error.status === 404) {
+                throw new EvalNotFoundError(evalId);
+            }
+            throw error;
+        }
+    }
+}
+exports.default = Evals;

--- a/dist/lib/resources/Knowledge.d.ts
+++ b/dist/lib/resources/Knowledge.d.ts
@@ -1,0 +1,61 @@
+import { stateset } from '../../stateset-client';
+export declare enum KnowledgeType {
+    DOCUMENT = "document",
+    FAQ = "faq",
+    ARTICLE = "article",
+    CODE_SNIPPET = "code_snippet",
+    LINK = "link"
+}
+export interface KnowledgeData {
+    title: string;
+    content: string;
+    type: KnowledgeType;
+    tags?: string[];
+    metadata?: Record<string, any>;
+    agent_id?: string;
+    org_id?: string;
+    user_id?: string;
+}
+export interface KnowledgeRecord {
+    id: string;
+    created_at: string;
+    updated_at: string;
+    data: KnowledgeData;
+}
+export declare class KnowledgeNotFoundError extends Error {
+    constructor(knowledgeId: string);
+}
+export declare class KnowledgeValidationError extends Error {
+    constructor(message: string);
+}
+declare class Knowledge {
+    private readonly stateset;
+    constructor(stateset: stateset);
+    /**
+     * List knowledge items with optional filtering
+     */
+    list(params?: {
+        type?: KnowledgeType;
+        agent_id?: string;
+        org_id?: string;
+        user_id?: string;
+        tag?: string;
+    }): Promise<KnowledgeRecord[]>;
+    /**
+     * Get specific knowledge item
+     */
+    get(knowledgeId: string): Promise<KnowledgeRecord>;
+    /**
+     * Create knowledge
+     */
+    create(data: KnowledgeData): Promise<KnowledgeRecord>;
+    /**
+     * Update knowledge
+     */
+    update(knowledgeId: string, data: Partial<KnowledgeData>): Promise<KnowledgeRecord>;
+    /**
+     * Delete knowledge
+     */
+    delete(knowledgeId: string): Promise<void>;
+}
+export default Knowledge;

--- a/dist/lib/resources/Knowledge.js
+++ b/dist/lib/resources/Knowledge.js
@@ -1,0 +1,106 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.KnowledgeValidationError = exports.KnowledgeNotFoundError = exports.KnowledgeType = void 0;
+// Enums for knowledge management
+var KnowledgeType;
+(function (KnowledgeType) {
+    KnowledgeType["DOCUMENT"] = "document";
+    KnowledgeType["FAQ"] = "faq";
+    KnowledgeType["ARTICLE"] = "article";
+    KnowledgeType["CODE_SNIPPET"] = "code_snippet";
+    KnowledgeType["LINK"] = "link";
+})(KnowledgeType = exports.KnowledgeType || (exports.KnowledgeType = {}));
+// Custom error classes
+class KnowledgeNotFoundError extends Error {
+    constructor(knowledgeId) {
+        super(`Knowledge with ID ${knowledgeId} not found`);
+        this.name = 'KnowledgeNotFoundError';
+    }
+}
+exports.KnowledgeNotFoundError = KnowledgeNotFoundError;
+class KnowledgeValidationError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'KnowledgeValidationError';
+    }
+}
+exports.KnowledgeValidationError = KnowledgeValidationError;
+// Main Knowledge class
+class Knowledge {
+    constructor(stateset) {
+        this.stateset = stateset;
+    }
+    /**
+     * List knowledge items with optional filtering
+     */
+    async list(params) {
+        const queryParams = new URLSearchParams();
+        if (params === null || params === void 0 ? void 0 : params.type)
+            queryParams.append('type', params.type);
+        if (params === null || params === void 0 ? void 0 : params.agent_id)
+            queryParams.append('agent_id', params.agent_id);
+        if (params === null || params === void 0 ? void 0 : params.org_id)
+            queryParams.append('org_id', params.org_id);
+        if (params === null || params === void 0 ? void 0 : params.user_id)
+            queryParams.append('user_id', params.user_id);
+        if (params === null || params === void 0 ? void 0 : params.tag)
+            queryParams.append('tag', params.tag);
+        const response = await this.stateset.request('GET', `knowledge?${queryParams.toString()}`);
+        return response.knowledge;
+    }
+    /**
+     * Get specific knowledge item
+     */
+    async get(knowledgeId) {
+        try {
+            const response = await this.stateset.request('GET', `knowledge/${knowledgeId}`);
+            return response.knowledge;
+        }
+        catch (error) {
+            if (error.status === 404) {
+                throw new KnowledgeNotFoundError(knowledgeId);
+            }
+            throw error;
+        }
+    }
+    /**
+     * Create knowledge
+     */
+    async create(data) {
+        if (!data.title || !data.content) {
+            throw new KnowledgeValidationError('Title and content are required');
+        }
+        const response = await this.stateset.request('POST', 'knowledge', data);
+        return response.knowledge;
+    }
+    /**
+     * Update knowledge
+     */
+    async update(knowledgeId, data) {
+        try {
+            const response = await this.stateset.request('PUT', `knowledge/${knowledgeId}`, data);
+            return response.knowledge;
+        }
+        catch (error) {
+            if (error.status === 404) {
+                throw new KnowledgeNotFoundError(knowledgeId);
+            }
+            throw error;
+        }
+    }
+    /**
+     * Delete knowledge
+     */
+    async delete(knowledgeId) {
+        try {
+            await this.stateset.request('DELETE', `knowledge/${knowledgeId}`);
+        }
+        catch (error) {
+            if (error.status === 404) {
+                throw new KnowledgeNotFoundError(knowledgeId);
+            }
+            throw error;
+        }
+    }
+}
+exports.default = Knowledge;

--- a/dist/lib/resources/Ledger.d.ts
+++ b/dist/lib/resources/Ledger.d.ts
@@ -1,0 +1,82 @@
+import { stateset } from '../../stateset-client';
+type NonEmptyString<T extends string> = T extends '' ? never : T;
+type Timestamp = string;
+export declare enum LedgerEventType {
+    PAYMENT = "PAYMENT",
+    REFUND = "REFUND",
+    CREDIT = "CREDIT",
+    DEBIT = "DEBIT",
+    ADJUSTMENT = "ADJUSTMENT",
+    SALE = "SALE",
+    PURCHASE = "PURCHASE"
+}
+export interface LedgerData {
+    event_type: LedgerEventType;
+    reference_id: NonEmptyString<string>;
+    customer_id?: NonEmptyString<string>;
+    amount: number;
+    currency: string;
+    event_date: Timestamp;
+    description: string;
+    account_id?: NonEmptyString<string>;
+    created_at: Timestamp;
+    updated_at: Timestamp;
+    org_id?: string;
+    metadata?: Record<string, any>;
+}
+export interface LedgerResponse {
+    id: NonEmptyString<string>;
+    object: 'ledger';
+    data: LedgerData;
+}
+export declare class LedgerError extends Error {
+    readonly details?: Record<string, unknown> | undefined;
+    constructor(message: string, details?: Record<string, unknown> | undefined);
+}
+export declare class LedgerNotFoundError extends LedgerError {
+    constructor(ledgerId: string);
+}
+export declare class LedgerValidationError extends LedgerError {
+    readonly errors?: Record<string, string> | undefined;
+    constructor(message: string, errors?: Record<string, string> | undefined);
+}
+export default class Ledger {
+    private readonly stateset;
+    constructor(stateset: stateset);
+    private validateLedgerData;
+    private mapResponse;
+    list(params?: {
+        event_type?: LedgerEventType;
+        reference_id?: string;
+        customer_id?: string;
+        org_id?: string;
+        date_from?: Date;
+        date_to?: Date;
+        limit?: number;
+        offset?: number;
+    }): Promise<{
+        ledger_entries: LedgerResponse[];
+        pagination: {
+            total: number;
+            limit: number;
+            offset: number;
+        };
+    }>;
+    get(ledgerId: NonEmptyString<string>): Promise<LedgerResponse>;
+    create(data: LedgerData): Promise<LedgerResponse>;
+    update(ledgerId: NonEmptyString<string>, data: Partial<LedgerData>): Promise<LedgerResponse>;
+    delete(ledgerId: NonEmptyString<string>): Promise<void>;
+    getBalance(params?: {
+        customer_id?: string;
+        org_id?: string;
+        date_from?: Date;
+        date_to?: Date;
+    }): Promise<{
+        total_credits: number;
+        total_debits: number;
+        net_balance: number;
+        currency: string;
+    }>;
+    private handleError;
+}
+export {};

--- a/dist/lib/resources/Ledger.js
+++ b/dist/lib/resources/Ledger.js
@@ -1,0 +1,168 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.LedgerValidationError = exports.LedgerNotFoundError = exports.LedgerError = exports.LedgerEventType = void 0;
+// Enums
+var LedgerEventType;
+(function (LedgerEventType) {
+    LedgerEventType["PAYMENT"] = "PAYMENT";
+    LedgerEventType["REFUND"] = "REFUND";
+    LedgerEventType["CREDIT"] = "CREDIT";
+    LedgerEventType["DEBIT"] = "DEBIT";
+    LedgerEventType["ADJUSTMENT"] = "ADJUSTMENT";
+    LedgerEventType["SALE"] = "SALE";
+    LedgerEventType["PURCHASE"] = "PURCHASE";
+})(LedgerEventType = exports.LedgerEventType || (exports.LedgerEventType = {}));
+// Error Classes
+class LedgerError extends Error {
+    constructor(message, details) {
+        super(message);
+        this.details = details;
+        this.name = 'LedgerError';
+    }
+}
+exports.LedgerError = LedgerError;
+class LedgerNotFoundError extends LedgerError {
+    constructor(ledgerId) {
+        super(`Ledger entry with ID ${ledgerId} not found`, { ledgerId });
+    }
+}
+exports.LedgerNotFoundError = LedgerNotFoundError;
+class LedgerValidationError extends LedgerError {
+    constructor(message, errors) {
+        super(message);
+        this.errors = errors;
+    }
+}
+exports.LedgerValidationError = LedgerValidationError;
+class Ledger {
+    constructor(stateset) {
+        this.stateset = stateset;
+    }
+    validateLedgerData(data) {
+        if (!data.reference_id)
+            throw new LedgerValidationError('Reference ID is required');
+        if (!data.event_date)
+            throw new LedgerValidationError('Event date is required');
+    }
+    mapResponse(data) {
+        if (!(data === null || data === void 0 ? void 0 : data.id))
+            throw new LedgerError('Invalid response format');
+        return {
+            id: data.id,
+            object: 'ledger',
+            data: {
+                event_type: data.event_type,
+                reference_id: data.reference_id,
+                customer_id: data.customer_id,
+                amount: data.amount,
+                currency: data.currency,
+                event_date: data.event_date,
+                description: data.description,
+                account_id: data.account_id,
+                created_at: data.created_at,
+                updated_at: data.updated_at,
+                org_id: data.org_id,
+                metadata: data.metadata,
+            },
+        };
+    }
+    async list(params) {
+        const queryParams = new URLSearchParams();
+        if (params) {
+            if (params.event_type)
+                queryParams.append('event_type', params.event_type);
+            if (params.reference_id)
+                queryParams.append('reference_id', params.reference_id);
+            if (params.customer_id)
+                queryParams.append('customer_id', params.customer_id);
+            if (params.org_id)
+                queryParams.append('org_id', params.org_id);
+            if (params.date_from)
+                queryParams.append('date_from', params.date_from.toISOString());
+            if (params.date_to)
+                queryParams.append('date_to', params.date_to.toISOString());
+            if (params.limit)
+                queryParams.append('limit', params.limit.toString());
+            if (params.offset)
+                queryParams.append('offset', params.offset.toString());
+        }
+        try {
+            const response = await this.stateset.request('GET', `ledger_entries?${queryParams.toString()}`);
+            return {
+                ledger_entries: response.ledger_entries.map(this.mapResponse),
+                pagination: {
+                    total: response.total || response.ledger_entries.length,
+                    limit: (params === null || params === void 0 ? void 0 : params.limit) || 100,
+                    offset: (params === null || params === void 0 ? void 0 : params.offset) || 0,
+                },
+            };
+        }
+        catch (error) {
+            throw this.handleError(error, 'list');
+        }
+    }
+    async get(ledgerId) {
+        try {
+            const response = await this.stateset.request('GET', `ledger_entries/${ledgerId}`);
+            return this.mapResponse(response.ledger_entry);
+        }
+        catch (error) {
+            throw this.handleError(error, 'get', ledgerId);
+        }
+    }
+    async create(data) {
+        this.validateLedgerData(data);
+        try {
+            const response = await this.stateset.request('POST', 'ledger_entries', data);
+            return this.mapResponse(response.ledger_entry);
+        }
+        catch (error) {
+            throw this.handleError(error, 'create');
+        }
+    }
+    async update(ledgerId, data) {
+        try {
+            const response = await this.stateset.request('PUT', `ledger_entries/${ledgerId}`, data);
+            return this.mapResponse(response.ledger_entry);
+        }
+        catch (error) {
+            throw this.handleError(error, 'update', ledgerId);
+        }
+    }
+    async delete(ledgerId) {
+        try {
+            await this.stateset.request('DELETE', `ledger_entries/${ledgerId}`);
+        }
+        catch (error) {
+            throw this.handleError(error, 'delete', ledgerId);
+        }
+    }
+    async getBalance(params) {
+        const queryParams = new URLSearchParams();
+        if (params) {
+            if (params.customer_id)
+                queryParams.append('customer_id', params.customer_id);
+            if (params.org_id)
+                queryParams.append('org_id', params.org_id);
+            if (params.date_from)
+                queryParams.append('date_from', params.date_from.toISOString());
+            if (params.date_to)
+                queryParams.append('date_to', params.date_to.toISOString());
+        }
+        try {
+            const response = await this.stateset.request('GET', `ledger_entries/balance?${queryParams.toString()}`);
+            return response;
+        }
+        catch (error) {
+            throw this.handleError(error, 'getBalance');
+        }
+    }
+    handleError(error, operation, ledgerId) {
+        if (error.status === 404)
+            throw new LedgerNotFoundError(ledgerId || 'unknown');
+        if (error.status === 400)
+            throw new LedgerValidationError(error.message, error.errors);
+        throw new LedgerError(`Failed to ${operation} ledger entry: ${error.message}`, { operation, originalError: error });
+    }
+}
+exports.default = Ledger;

--- a/dist/lib/resources/MaintenanceSchedule.d.ts
+++ b/dist/lib/resources/MaintenanceSchedule.d.ts
@@ -1,0 +1,86 @@
+import { stateset } from '../../stateset-client';
+type NonEmptyString<T extends string> = T extends '' ? never : T;
+type Timestamp = string;
+export declare enum MaintenanceScheduleStatus {
+    SCHEDULED = "SCHEDULED",
+    IN_PROGRESS = "IN_PROGRESS",
+    COMPLETED = "COMPLETED",
+    CANCELLED = "CANCELLED",
+    OVERDUE = "OVERDUE"
+}
+export declare enum MaintenanceType {
+    PREVENTIVE = "PREVENTIVE",
+    CORRECTIVE = "CORRECTIVE",
+    PREDICTIVE = "PREDICTIVE"
+}
+export interface MaintenanceScheduleData {
+    asset_id: NonEmptyString<string>;
+    machine_id?: NonEmptyString<string>;
+    status: MaintenanceScheduleStatus;
+    type: MaintenanceType;
+    scheduled_date: Timestamp;
+    due_date: Timestamp;
+    completed_date?: Timestamp;
+    technician_id?: NonEmptyString<string>;
+    description: string;
+    duration_estimate: number;
+    actual_duration?: number;
+    cost_estimate: number;
+    actual_cost?: number;
+    currency: string;
+    notes?: string[];
+    created_at: Timestamp;
+    updated_at: Timestamp;
+    org_id?: string;
+    metadata?: Record<string, any>;
+}
+export interface MaintenanceScheduleResponse {
+    id: NonEmptyString<string>;
+    object: 'maintenance_schedule';
+    data: MaintenanceScheduleData;
+}
+export declare class MaintenanceScheduleError extends Error {
+    readonly details?: Record<string, unknown> | undefined;
+    constructor(message: string, details?: Record<string, unknown> | undefined);
+}
+export declare class MaintenanceScheduleNotFoundError extends MaintenanceScheduleError {
+    constructor(maintenanceScheduleId: string);
+}
+export declare class MaintenanceScheduleValidationError extends MaintenanceScheduleError {
+    readonly errors?: Record<string, string> | undefined;
+    constructor(message: string, errors?: Record<string, string> | undefined);
+}
+export default class MaintenanceSchedules {
+    private readonly stateset;
+    constructor(stateset: stateset);
+    private validateMaintenanceScheduleData;
+    private mapResponse;
+    list(params?: {
+        asset_id?: string;
+        status?: MaintenanceScheduleStatus;
+        type?: MaintenanceType;
+        org_id?: string;
+        date_from?: Date;
+        date_to?: Date;
+        limit?: number;
+        offset?: number;
+    }): Promise<{
+        maintenance_schedules: MaintenanceScheduleResponse[];
+        pagination: {
+            total: number;
+            limit: number;
+            offset: number;
+        };
+    }>;
+    get(maintenanceScheduleId: NonEmptyString<string>): Promise<MaintenanceScheduleResponse>;
+    create(data: MaintenanceScheduleData): Promise<MaintenanceScheduleResponse>;
+    update(maintenanceScheduleId: NonEmptyString<string>, data: Partial<MaintenanceScheduleData>): Promise<MaintenanceScheduleResponse>;
+    delete(maintenanceScheduleId: NonEmptyString<string>): Promise<void>;
+    complete(maintenanceScheduleId: NonEmptyString<string>, completionData: {
+        completed_date: Timestamp;
+        actual_duration: number;
+        actual_cost: number;
+    }): Promise<MaintenanceScheduleResponse>;
+    private handleError;
+}
+export {};

--- a/dist/lib/resources/MaintenanceSchedule.js
+++ b/dist/lib/resources/MaintenanceSchedule.js
@@ -1,0 +1,174 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MaintenanceScheduleValidationError = exports.MaintenanceScheduleNotFoundError = exports.MaintenanceScheduleError = exports.MaintenanceType = exports.MaintenanceScheduleStatus = void 0;
+// Enums
+var MaintenanceScheduleStatus;
+(function (MaintenanceScheduleStatus) {
+    MaintenanceScheduleStatus["SCHEDULED"] = "SCHEDULED";
+    MaintenanceScheduleStatus["IN_PROGRESS"] = "IN_PROGRESS";
+    MaintenanceScheduleStatus["COMPLETED"] = "COMPLETED";
+    MaintenanceScheduleStatus["CANCELLED"] = "CANCELLED";
+    MaintenanceScheduleStatus["OVERDUE"] = "OVERDUE";
+})(MaintenanceScheduleStatus = exports.MaintenanceScheduleStatus || (exports.MaintenanceScheduleStatus = {}));
+var MaintenanceType;
+(function (MaintenanceType) {
+    MaintenanceType["PREVENTIVE"] = "PREVENTIVE";
+    MaintenanceType["CORRECTIVE"] = "CORRECTIVE";
+    MaintenanceType["PREDICTIVE"] = "PREDICTIVE";
+})(MaintenanceType = exports.MaintenanceType || (exports.MaintenanceType = {}));
+// Error Classes
+class MaintenanceScheduleError extends Error {
+    constructor(message, details) {
+        super(message);
+        this.details = details;
+        this.name = 'MaintenanceScheduleError';
+    }
+}
+exports.MaintenanceScheduleError = MaintenanceScheduleError;
+class MaintenanceScheduleNotFoundError extends MaintenanceScheduleError {
+    constructor(maintenanceScheduleId) {
+        super(`Maintenance schedule with ID ${maintenanceScheduleId} not found`, { maintenanceScheduleId });
+    }
+}
+exports.MaintenanceScheduleNotFoundError = MaintenanceScheduleNotFoundError;
+class MaintenanceScheduleValidationError extends MaintenanceScheduleError {
+    constructor(message, errors) {
+        super(message);
+        this.errors = errors;
+    }
+}
+exports.MaintenanceScheduleValidationError = MaintenanceScheduleValidationError;
+class MaintenanceSchedules {
+    constructor(stateset) {
+        this.stateset = stateset;
+    }
+    validateMaintenanceScheduleData(data) {
+        if (!data.asset_id)
+            throw new MaintenanceScheduleValidationError('Asset ID is required');
+        if (!data.scheduled_date)
+            throw new MaintenanceScheduleValidationError('Scheduled date is required');
+        if (!data.due_date)
+            throw new MaintenanceScheduleValidationError('Due date is required');
+        if (data.duration_estimate < 0)
+            throw new MaintenanceScheduleValidationError('Duration estimate cannot be negative');
+        if (data.cost_estimate < 0)
+            throw new MaintenanceScheduleValidationError('Cost estimate cannot be negative');
+    }
+    mapResponse(data) {
+        if (!(data === null || data === void 0 ? void 0 : data.id))
+            throw new MaintenanceScheduleError('Invalid response format');
+        return {
+            id: data.id,
+            object: 'maintenance_schedule',
+            data: {
+                asset_id: data.asset_id,
+                machine_id: data.machine_id,
+                status: data.status,
+                type: data.type,
+                scheduled_date: data.scheduled_date,
+                due_date: data.due_date,
+                completed_date: data.completed_date,
+                technician_id: data.technician_id,
+                description: data.description,
+                duration_estimate: data.duration_estimate,
+                actual_duration: data.actual_duration,
+                cost_estimate: data.cost_estimate,
+                actual_cost: data.actual_cost,
+                currency: data.currency,
+                notes: data.notes,
+                created_at: data.created_at,
+                updated_at: data.updated_at,
+                org_id: data.org_id,
+                metadata: data.metadata,
+            },
+        };
+    }
+    async list(params) {
+        const queryParams = new URLSearchParams();
+        if (params) {
+            if (params.asset_id)
+                queryParams.append('asset_id', params.asset_id);
+            if (params.status)
+                queryParams.append('status', params.status);
+            if (params.type)
+                queryParams.append('type', params.type);
+            if (params.org_id)
+                queryParams.append('org_id', params.org_id);
+            if (params.date_from)
+                queryParams.append('date_from', params.date_from.toISOString());
+            if (params.date_to)
+                queryParams.append('date_to', params.date_to.toISOString());
+            if (params.limit)
+                queryParams.append('limit', params.limit.toString());
+            if (params.offset)
+                queryParams.append('offset', params.offset.toString());
+        }
+        try {
+            const response = await this.stateset.request('GET', `maintenance_schedules?${queryParams.toString()}`);
+            return {
+                maintenance_schedules: response.maintenance_schedules.map(this.mapResponse),
+                pagination: {
+                    total: response.total || response.maintenance_schedules.length,
+                    limit: (params === null || params === void 0 ? void 0 : params.limit) || 100,
+                    offset: (params === null || params === void 0 ? void 0 : params.offset) || 0,
+                },
+            };
+        }
+        catch (error) {
+            throw this.handleError(error, 'list');
+        }
+    }
+    async get(maintenanceScheduleId) {
+        try {
+            const response = await this.stateset.request('GET', `maintenance_schedules/${maintenanceScheduleId}`);
+            return this.mapResponse(response.maintenance_schedule);
+        }
+        catch (error) {
+            throw this.handleError(error, 'get', maintenanceScheduleId);
+        }
+    }
+    async create(data) {
+        this.validateMaintenanceScheduleData(data);
+        try {
+            const response = await this.stateset.request('POST', 'maintenance_schedules', data);
+            return this.mapResponse(response.maintenance_schedule);
+        }
+        catch (error) {
+            throw this.handleError(error, 'create');
+        }
+    }
+    async update(maintenanceScheduleId, data) {
+        try {
+            const response = await this.stateset.request('PUT', `maintenance_schedules/${maintenanceScheduleId}`, data);
+            return this.mapResponse(response.maintenance_schedule);
+        }
+        catch (error) {
+            throw this.handleError(error, 'update', maintenanceScheduleId);
+        }
+    }
+    async delete(maintenanceScheduleId) {
+        try {
+            await this.stateset.request('DELETE', `maintenance_schedules/${maintenanceScheduleId}`);
+        }
+        catch (error) {
+            throw this.handleError(error, 'delete', maintenanceScheduleId);
+        }
+    }
+    async complete(maintenanceScheduleId, completionData) {
+        try {
+            const response = await this.stateset.request('POST', `maintenance_schedules/${maintenanceScheduleId}/complete`, completionData);
+            return this.mapResponse(response.maintenance_schedule);
+        }
+        catch (error) {
+            throw this.handleError(error, 'complete', maintenanceScheduleId);
+        }
+    }
+    handleError(error, operation, maintenanceScheduleId) {
+        if (error.status === 404)
+            throw new MaintenanceScheduleNotFoundError(maintenanceScheduleId || 'unknown');
+        if (error.status === 400)
+            throw new MaintenanceScheduleValidationError(error.message, error.errors);
+        throw new MaintenanceScheduleError(`Failed to ${operation} maintenance schedule: ${error.message}`, { operation, originalError: error });
+    }
+}
+exports.default = MaintenanceSchedules;

--- a/dist/lib/resources/Opportunity.d.ts
+++ b/dist/lib/resources/Opportunity.d.ts
@@ -1,0 +1,80 @@
+import { stateset } from '../../stateset-client';
+type NonEmptyString<T extends string> = T extends '' ? never : T;
+type Timestamp = string;
+export declare enum OpportunityStatus {
+    PROSPECTING = "PROSPECTING",
+    QUALIFIED = "QUALIFIED",
+    PROPOSAL_SENT = "PROPOSAL_SENT",
+    NEGOTIATION = "NEGOTIATION",
+    WON = "WON",
+    LOST = "LOST",
+    ON_HOLD = "ON_HOLD"
+}
+export declare enum OpportunityStage {
+    LEAD = "LEAD",
+    OPPORTUNITY = "OPPORTUNITY",
+    CUSTOMER = "CUSTOMER"
+}
+export interface OpportunityData {
+    lead_id: NonEmptyString<string>;
+    customer_id?: NonEmptyString<string>;
+    status: OpportunityStatus;
+    stage: OpportunityStage;
+    amount: number;
+    currency: string;
+    expected_close_date?: Timestamp;
+    assigned_to: NonEmptyString<string>;
+    description: string;
+    probability: number;
+    created_at: Timestamp;
+    updated_at: Timestamp;
+    org_id?: string;
+    metadata?: Record<string, any>;
+}
+export interface OpportunityResponse {
+    id: NonEmptyString<string>;
+    object: 'opportunity';
+    data: OpportunityData;
+}
+export declare class OpportunityError extends Error {
+    readonly details?: Record<string, unknown> | undefined;
+    constructor(message: string, details?: Record<string, unknown> | undefined);
+}
+export declare class OpportunityNotFoundError extends OpportunityError {
+    constructor(opportunityId: string);
+}
+export declare class OpportunityValidationError extends OpportunityError {
+    readonly errors?: Record<string, string> | undefined;
+    constructor(message: string, errors?: Record<string, string> | undefined);
+}
+export default class Opportunities {
+    private readonly stateset;
+    constructor(stateset: stateset);
+    private validateOpportunityData;
+    private mapResponse;
+    list(params?: {
+        lead_id?: string;
+        customer_id?: string;
+        status?: OpportunityStatus;
+        stage?: OpportunityStage;
+        org_id?: string;
+        date_from?: Date;
+        date_to?: Date;
+        limit?: number;
+        offset?: number;
+    }): Promise<{
+        opportunities: OpportunityResponse[];
+        pagination: {
+            total: number;
+            limit: number;
+            offset: number;
+        };
+    }>;
+    get(opportunityId: NonEmptyString<string>): Promise<OpportunityResponse>;
+    create(data: OpportunityData): Promise<OpportunityResponse>;
+    update(opportunityId: NonEmptyString<string>, data: Partial<OpportunityData>): Promise<OpportunityResponse>;
+    delete(opportunityId: NonEmptyString<string>): Promise<void>;
+    convertToCustomer(opportunityId: NonEmptyString<string>, customerId: NonEmptyString<string>): Promise<OpportunityResponse>;
+    private handleError;
+}
+export {};

--- a/dist/lib/resources/Opportunity.js
+++ b/dist/lib/resources/Opportunity.js
@@ -1,0 +1,172 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.OpportunityValidationError = exports.OpportunityNotFoundError = exports.OpportunityError = exports.OpportunityStage = exports.OpportunityStatus = void 0;
+// Enums
+var OpportunityStatus;
+(function (OpportunityStatus) {
+    OpportunityStatus["PROSPECTING"] = "PROSPECTING";
+    OpportunityStatus["QUALIFIED"] = "QUALIFIED";
+    OpportunityStatus["PROPOSAL_SENT"] = "PROPOSAL_SENT";
+    OpportunityStatus["NEGOTIATION"] = "NEGOTIATION";
+    OpportunityStatus["WON"] = "WON";
+    OpportunityStatus["LOST"] = "LOST";
+    OpportunityStatus["ON_HOLD"] = "ON_HOLD";
+})(OpportunityStatus = exports.OpportunityStatus || (exports.OpportunityStatus = {}));
+var OpportunityStage;
+(function (OpportunityStage) {
+    OpportunityStage["LEAD"] = "LEAD";
+    OpportunityStage["OPPORTUNITY"] = "OPPORTUNITY";
+    OpportunityStage["CUSTOMER"] = "CUSTOMER";
+})(OpportunityStage = exports.OpportunityStage || (exports.OpportunityStage = {}));
+// Error Classes
+class OpportunityError extends Error {
+    constructor(message, details) {
+        super(message);
+        this.details = details;
+        this.name = 'OpportunityError';
+    }
+}
+exports.OpportunityError = OpportunityError;
+class OpportunityNotFoundError extends OpportunityError {
+    constructor(opportunityId) {
+        super(`Opportunity with ID ${opportunityId} not found`, { opportunityId });
+    }
+}
+exports.OpportunityNotFoundError = OpportunityNotFoundError;
+class OpportunityValidationError extends OpportunityError {
+    constructor(message, errors) {
+        super(message);
+        this.errors = errors;
+    }
+}
+exports.OpportunityValidationError = OpportunityValidationError;
+class Opportunities {
+    constructor(stateset) {
+        this.stateset = stateset;
+    }
+    validateOpportunityData(data) {
+        if (!data.lead_id)
+            throw new OpportunityValidationError('Lead ID is required');
+        if (!data.assigned_to)
+            throw new OpportunityValidationError('Assigned user ID is required');
+        if (data.amount < 0)
+            throw new OpportunityValidationError('Amount cannot be negative');
+        if (data.probability < 0 || data.probability > 100) {
+            throw new OpportunityValidationError('Probability must be between 0 and 100');
+        }
+    }
+    mapResponse(data) {
+        if (!(data === null || data === void 0 ? void 0 : data.id))
+            throw new OpportunityError('Invalid response format');
+        return {
+            id: data.id,
+            object: 'opportunity',
+            data: {
+                lead_id: data.lead_id,
+                customer_id: data.customer_id,
+                status: data.status,
+                stage: data.stage,
+                amount: data.amount,
+                currency: data.currency,
+                expected_close_date: data.expected_close_date,
+                assigned_to: data.assigned_to,
+                description: data.description,
+                probability: data.probability,
+                created_at: data.created_at,
+                updated_at: data.updated_at,
+                org_id: data.org_id,
+                metadata: data.metadata,
+            },
+        };
+    }
+    async list(params) {
+        const queryParams = new URLSearchParams();
+        if (params) {
+            if (params.lead_id)
+                queryParams.append('lead_id', params.lead_id);
+            if (params.customer_id)
+                queryParams.append('customer_id', params.customer_id);
+            if (params.status)
+                queryParams.append('status', params.status);
+            if (params.stage)
+                queryParams.append('stage', params.stage);
+            if (params.org_id)
+                queryParams.append('org_id', params.org_id);
+            if (params.date_from)
+                queryParams.append('date_from', params.date_from.toISOString());
+            if (params.date_to)
+                queryParams.append('date_to', params.date_to.toISOString());
+            if (params.limit)
+                queryParams.append('limit', params.limit.toString());
+            if (params.offset)
+                queryParams.append('offset', params.offset.toString());
+        }
+        try {
+            const response = await this.stateset.request('GET', `opportunities?${queryParams.toString()}`);
+            return {
+                opportunities: response.opportunities.map(this.mapResponse),
+                pagination: {
+                    total: response.total || response.opportunities.length,
+                    limit: (params === null || params === void 0 ? void 0 : params.limit) || 100,
+                    offset: (params === null || params === void 0 ? void 0 : params.offset) || 0,
+                },
+            };
+        }
+        catch (error) {
+            throw this.handleError(error, 'list');
+        }
+    }
+    async get(opportunityId) {
+        try {
+            const response = await this.stateset.request('GET', `opportunities/${opportunityId}`);
+            return this.mapResponse(response.opportunity);
+        }
+        catch (error) {
+            throw this.handleError(error, 'get', opportunityId);
+        }
+    }
+    async create(data) {
+        this.validateOpportunityData(data);
+        try {
+            const response = await this.stateset.request('POST', 'opportunities', data);
+            return this.mapResponse(response.opportunity);
+        }
+        catch (error) {
+            throw this.handleError(error, 'create');
+        }
+    }
+    async update(opportunityId, data) {
+        try {
+            const response = await this.stateset.request('PUT', `opportunities/${opportunityId}`, data);
+            return this.mapResponse(response.opportunity);
+        }
+        catch (error) {
+            throw this.handleError(error, 'update', opportunityId);
+        }
+    }
+    async delete(opportunityId) {
+        try {
+            await this.stateset.request('DELETE', `opportunities/${opportunityId}`);
+        }
+        catch (error) {
+            throw this.handleError(error, 'delete', opportunityId);
+        }
+    }
+    async convertToCustomer(opportunityId, customerId) {
+        try {
+            const response = await this.stateset.request('POST', `opportunities/${opportunityId}/convert`, { customer_id: customerId });
+            return this.mapResponse(response.opportunity);
+        }
+        catch (error) {
+            throw this.handleError(error, 'convertToCustomer', opportunityId);
+        }
+    }
+    handleError(error, operation, opportunityId) {
+        if (error.status === 404)
+            throw new OpportunityNotFoundError(opportunityId || 'unknown');
+        if (error.status === 400)
+            throw new OpportunityValidationError(error.message, error.errors);
+        throw new OpportunityError(`Failed to ${operation} opportunity: ${error.message}`, { operation, originalError: error });
+    }
+}
+exports.default = Opportunities;

--- a/dist/lib/resources/QualityControl.d.ts
+++ b/dist/lib/resources/QualityControl.d.ts
@@ -1,0 +1,83 @@
+import { stateset } from '../../stateset-client';
+type NonEmptyString<T extends string> = T extends '' ? never : T;
+type Timestamp = string;
+export declare enum QualityControlStatus {
+    PENDING = "PENDING",
+    IN_PROGRESS = "IN_PROGRESS",
+    PASSED = "PASSED",
+    FAILED = "FAILED",
+    ON_HOLD = "ON_HOLD"
+}
+export interface QualityControlData {
+    order_id?: NonEmptyString<string>;
+    product_id?: NonEmptyString<string>;
+    status: QualityControlStatus;
+    inspection_date: Timestamp;
+    inspector_id: NonEmptyString<string>;
+    standards: Array<{
+        parameter: string;
+        specification: string;
+        tolerance?: {
+            min: number;
+            max: number;
+            unit: string;
+        };
+    }>;
+    results: Array<{
+        parameter: string;
+        actual_value: string;
+        passed: boolean;
+        notes?: string;
+    }>;
+    notes?: string[];
+    created_at: Timestamp;
+    updated_at: Timestamp;
+    org_id?: string;
+    metadata?: Record<string, any>;
+}
+export interface QualityControlResponse {
+    id: NonEmptyString<string>;
+    object: 'quality_control';
+    data: QualityControlData;
+}
+export declare class QualityControlError extends Error {
+    readonly details?: Record<string, unknown> | undefined;
+    constructor(message: string, details?: Record<string, unknown> | undefined);
+}
+export declare class QualityControlNotFoundError extends QualityControlError {
+    constructor(qualityControlId: string);
+}
+export declare class QualityControlValidationError extends QualityControlError {
+    readonly errors?: Record<string, string> | undefined;
+    constructor(message: string, errors?: Record<string, string> | undefined);
+}
+export default class QualityControl {
+    private readonly stateset;
+    constructor(stateset: stateset);
+    private validateQualityControlData;
+    private mapResponse;
+    list(params?: {
+        order_id?: string;
+        product_id?: string;
+        status?: QualityControlStatus;
+        org_id?: string;
+        date_from?: Date;
+        date_to?: Date;
+        limit?: number;
+        offset?: number;
+    }): Promise<{
+        quality_controls: QualityControlResponse[];
+        pagination: {
+            total: number;
+            limit: number;
+            offset: number;
+        };
+    }>;
+    get(qualityControlId: NonEmptyString<string>): Promise<QualityControlResponse>;
+    create(data: QualityControlData): Promise<QualityControlResponse>;
+    update(qualityControlId: NonEmptyString<string>, data: Partial<QualityControlData>): Promise<QualityControlResponse>;
+    delete(qualityControlId: NonEmptyString<string>): Promise<void>;
+    recordResults(qualityControlId: NonEmptyString<string>, results: QualityControlData['results']): Promise<QualityControlResponse>;
+    private handleError;
+}
+export {};

--- a/dist/lib/resources/QualityControl.js
+++ b/dist/lib/resources/QualityControl.js
@@ -1,0 +1,158 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.QualityControlValidationError = exports.QualityControlNotFoundError = exports.QualityControlError = exports.QualityControlStatus = void 0;
+// Enums
+var QualityControlStatus;
+(function (QualityControlStatus) {
+    QualityControlStatus["PENDING"] = "PENDING";
+    QualityControlStatus["IN_PROGRESS"] = "IN_PROGRESS";
+    QualityControlStatus["PASSED"] = "PASSED";
+    QualityControlStatus["FAILED"] = "FAILED";
+    QualityControlStatus["ON_HOLD"] = "ON_HOLD";
+})(QualityControlStatus = exports.QualityControlStatus || (exports.QualityControlStatus = {}));
+// Error Classes
+class QualityControlError extends Error {
+    constructor(message, details) {
+        super(message);
+        this.details = details;
+        this.name = 'QualityControlError';
+    }
+}
+exports.QualityControlError = QualityControlError;
+class QualityControlNotFoundError extends QualityControlError {
+    constructor(qualityControlId) {
+        super(`Quality control with ID ${qualityControlId} not found`, { qualityControlId });
+    }
+}
+exports.QualityControlNotFoundError = QualityControlNotFoundError;
+class QualityControlValidationError extends QualityControlError {
+    constructor(message, errors) {
+        super(message);
+        this.errors = errors;
+    }
+}
+exports.QualityControlValidationError = QualityControlValidationError;
+class QualityControl {
+    constructor(stateset) {
+        this.stateset = stateset;
+    }
+    validateQualityControlData(data) {
+        var _a;
+        if (!data.inspector_id)
+            throw new QualityControlValidationError('Inspector ID is required');
+        if (!data.inspection_date)
+            throw new QualityControlValidationError('Inspection date is required');
+        if (!((_a = data.standards) === null || _a === void 0 ? void 0 : _a.length))
+            throw new QualityControlValidationError('At least one quality standard is required');
+    }
+    mapResponse(data) {
+        if (!(data === null || data === void 0 ? void 0 : data.id))
+            throw new QualityControlError('Invalid response format');
+        return {
+            id: data.id,
+            object: 'quality_control',
+            data: {
+                order_id: data.order_id,
+                product_id: data.product_id,
+                status: data.status,
+                inspection_date: data.inspection_date,
+                inspector_id: data.inspector_id,
+                standards: data.standards,
+                results: data.results,
+                notes: data.notes,
+                created_at: data.created_at,
+                updated_at: data.updated_at,
+                org_id: data.org_id,
+                metadata: data.metadata,
+            },
+        };
+    }
+    async list(params) {
+        const queryParams = new URLSearchParams();
+        if (params) {
+            if (params.order_id)
+                queryParams.append('order_id', params.order_id);
+            if (params.product_id)
+                queryParams.append('product_id', params.product_id);
+            if (params.status)
+                queryParams.append('status', params.status);
+            if (params.org_id)
+                queryParams.append('org_id', params.org_id);
+            if (params.date_from)
+                queryParams.append('date_from', params.date_from.toISOString());
+            if (params.date_to)
+                queryParams.append('date_to', params.date_to.toISOString());
+            if (params.limit)
+                queryParams.append('limit', params.limit.toString());
+            if (params.offset)
+                queryParams.append('offset', params.offset.toString());
+        }
+        try {
+            const response = await this.stateset.request('GET', `quality_controls?${queryParams.toString()}`);
+            return {
+                quality_controls: response.quality_controls.map(this.mapResponse),
+                pagination: {
+                    total: response.total || response.quality_controls.length,
+                    limit: (params === null || params === void 0 ? void 0 : params.limit) || 100,
+                    offset: (params === null || params === void 0 ? void 0 : params.offset) || 0,
+                },
+            };
+        }
+        catch (error) {
+            throw this.handleError(error, 'list');
+        }
+    }
+    async get(qualityControlId) {
+        try {
+            const response = await this.stateset.request('GET', `quality_controls/${qualityControlId}`);
+            return this.mapResponse(response.quality_control);
+        }
+        catch (error) {
+            throw this.handleError(error, 'get', qualityControlId);
+        }
+    }
+    async create(data) {
+        this.validateQualityControlData(data);
+        try {
+            const response = await this.stateset.request('POST', 'quality_controls', data);
+            return this.mapResponse(response.quality_control);
+        }
+        catch (error) {
+            throw this.handleError(error, 'create');
+        }
+    }
+    async update(qualityControlId, data) {
+        try {
+            const response = await this.stateset.request('PUT', `quality_controls/${qualityControlId}`, data);
+            return this.mapResponse(response.quality_control);
+        }
+        catch (error) {
+            throw this.handleError(error, 'update', qualityControlId);
+        }
+    }
+    async delete(qualityControlId) {
+        try {
+            await this.stateset.request('DELETE', `quality_controls/${qualityControlId}`);
+        }
+        catch (error) {
+            throw this.handleError(error, 'delete', qualityControlId);
+        }
+    }
+    async recordResults(qualityControlId, results) {
+        try {
+            const response = await this.stateset.request('POST', `quality_controls/${qualityControlId}/results`, { results });
+            return this.mapResponse(response.quality_control);
+        }
+        catch (error) {
+            throw this.handleError(error, 'recordResults', qualityControlId);
+        }
+    }
+    handleError(error, operation, qualityControlId) {
+        if (error.status === 404)
+            throw new QualityControlNotFoundError(qualityControlId || 'unknown');
+        if (error.status === 400)
+            throw new QualityControlValidationError(error.message, error.errors);
+        throw new QualityControlError(`Failed to ${operation} quality control: ${error.message}`, { operation, originalError: error });
+    }
+}
+exports.default = QualityControl;

--- a/dist/lib/resources/Refund.d.ts
+++ b/dist/lib/resources/Refund.d.ts
@@ -1,0 +1,77 @@
+import { stateset } from '../../stateset-client';
+type NonEmptyString<T extends string> = T extends '' ? never : T;
+type Timestamp = string;
+export declare enum RefundStatus {
+    PENDING = "PENDING",
+    APPROVED = "APPROVED",
+    PROCESSED = "PROCESSED",
+    REJECTED = "REJECTED",
+    CANCELLED = "CANCELLED"
+}
+export declare enum RefundReason {
+    RETURN = "RETURN",
+    CANCELLATION = "CANCELLATION",
+    DEFECTIVE = "DEFECTIVE",
+    OTHER = "OTHER"
+}
+export interface RefundData {
+    payment_id: NonEmptyString<string>;
+    return_id?: NonEmptyString<string>;
+    order_id?: NonEmptyString<string>;
+    status: RefundStatus;
+    reason: RefundReason;
+    amount: number;
+    currency: string;
+    refund_date?: Timestamp;
+    notes?: string[];
+    created_at: Timestamp;
+    updated_at: Timestamp;
+    org_id?: string;
+    metadata?: Record<string, any>;
+}
+export interface RefundResponse {
+    id: NonEmptyString<string>;
+    object: 'refund';
+    data: RefundData;
+}
+export declare class RefundError extends Error {
+    readonly details?: Record<string, unknown> | undefined;
+    constructor(message: string, details?: Record<string, unknown> | undefined);
+}
+export declare class RefundNotFoundError extends RefundError {
+    constructor(refundId: string);
+}
+export declare class RefundValidationError extends RefundError {
+    readonly errors?: Record<string, string> | undefined;
+    constructor(message: string, errors?: Record<string, string> | undefined);
+}
+export default class Refunds {
+    private readonly stateset;
+    constructor(stateset: stateset);
+    private validateRefundData;
+    private mapResponse;
+    list(params?: {
+        payment_id?: string;
+        return_id?: string;
+        status?: RefundStatus;
+        org_id?: string;
+        date_from?: Date;
+        date_to?: Date;
+        limit?: number;
+        offset?: number;
+    }): Promise<{
+        refunds: RefundResponse[];
+        pagination: {
+            total: number;
+            limit: number;
+            offset: number;
+        };
+    }>;
+    get(refundId: NonEmptyString<string>): Promise<RefundResponse>;
+    create(data: RefundData): Promise<RefundResponse>;
+    update(refundId: NonEmptyString<string>, data: Partial<RefundData>): Promise<RefundResponse>;
+    delete(refundId: NonEmptyString<string>): Promise<void>;
+    processRefund(refundId: NonEmptyString<string>, refundDate: Timestamp): Promise<RefundResponse>;
+    private handleError;
+}
+export {};

--- a/dist/lib/resources/Refund.js
+++ b/dist/lib/resources/Refund.js
@@ -1,0 +1,163 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.RefundValidationError = exports.RefundNotFoundError = exports.RefundError = exports.RefundReason = exports.RefundStatus = void 0;
+// Enums
+var RefundStatus;
+(function (RefundStatus) {
+    RefundStatus["PENDING"] = "PENDING";
+    RefundStatus["APPROVED"] = "APPROVED";
+    RefundStatus["PROCESSED"] = "PROCESSED";
+    RefundStatus["REJECTED"] = "REJECTED";
+    RefundStatus["CANCELLED"] = "CANCELLED";
+})(RefundStatus = exports.RefundStatus || (exports.RefundStatus = {}));
+var RefundReason;
+(function (RefundReason) {
+    RefundReason["RETURN"] = "RETURN";
+    RefundReason["CANCELLATION"] = "CANCELLATION";
+    RefundReason["DEFECTIVE"] = "DEFECTIVE";
+    RefundReason["OTHER"] = "OTHER";
+})(RefundReason = exports.RefundReason || (exports.RefundReason = {}));
+// Error Classes
+class RefundError extends Error {
+    constructor(message, details) {
+        super(message);
+        this.details = details;
+        this.name = 'RefundError';
+    }
+}
+exports.RefundError = RefundError;
+class RefundNotFoundError extends RefundError {
+    constructor(refundId) {
+        super(`Refund with ID ${refundId} not found`, { refundId });
+    }
+}
+exports.RefundNotFoundError = RefundNotFoundError;
+class RefundValidationError extends RefundError {
+    constructor(message, errors) {
+        super(message);
+        this.errors = errors;
+    }
+}
+exports.RefundValidationError = RefundValidationError;
+class Refunds {
+    constructor(stateset) {
+        this.stateset = stateset;
+    }
+    validateRefundData(data) {
+        if (!data.payment_id)
+            throw new RefundValidationError('Payment ID is required');
+        if (data.amount <= 0)
+            throw new RefundValidationError('Amount must be greater than 0');
+    }
+    mapResponse(data) {
+        if (!(data === null || data === void 0 ? void 0 : data.id))
+            throw new RefundError('Invalid response format');
+        return {
+            id: data.id,
+            object: 'refund',
+            data: {
+                payment_id: data.payment_id,
+                return_id: data.return_id,
+                order_id: data.order_id,
+                status: data.status,
+                reason: data.reason,
+                amount: data.amount,
+                currency: data.currency,
+                refund_date: data.refund_date,
+                notes: data.notes,
+                created_at: data.created_at,
+                updated_at: data.updated_at,
+                org_id: data.org_id,
+                metadata: data.metadata,
+            },
+        };
+    }
+    async list(params) {
+        const queryParams = new URLSearchParams();
+        if (params) {
+            if (params.payment_id)
+                queryParams.append('payment_id', params.payment_id);
+            if (params.return_id)
+                queryParams.append('return_id', params.return_id);
+            if (params.status)
+                queryParams.append('status', params.status);
+            if (params.org_id)
+                queryParams.append('org_id', params.org_id);
+            if (params.date_from)
+                queryParams.append('date_from', params.date_from.toISOString());
+            if (params.date_to)
+                queryParams.append('date_to', params.date_to.toISOString());
+            if (params.limit)
+                queryParams.append('limit', params.limit.toString());
+            if (params.offset)
+                queryParams.append('offset', params.offset.toString());
+        }
+        try {
+            const response = await this.stateset.request('GET', `refunds?${queryParams.toString()}`);
+            return {
+                refunds: response.refunds.map(this.mapResponse),
+                pagination: {
+                    total: response.total || response.refunds.length,
+                    limit: (params === null || params === void 0 ? void 0 : params.limit) || 100,
+                    offset: (params === null || params === void 0 ? void 0 : params.offset) || 0,
+                },
+            };
+        }
+        catch (error) {
+            throw this.handleError(error, 'list');
+        }
+    }
+    async get(refundId) {
+        try {
+            const response = await this.stateset.request('GET', `refunds/${refundId}`);
+            return this.mapResponse(response.refund);
+        }
+        catch (error) {
+            throw this.handleError(error, 'get', refundId);
+        }
+    }
+    async create(data) {
+        this.validateRefundData(data);
+        try {
+            const response = await this.stateset.request('POST', 'refunds', data);
+            return this.mapResponse(response.refund);
+        }
+        catch (error) {
+            throw this.handleError(error, 'create');
+        }
+    }
+    async update(refundId, data) {
+        try {
+            const response = await this.stateset.request('PUT', `refunds/${refundId}`, data);
+            return this.mapResponse(response.refund);
+        }
+        catch (error) {
+            throw this.handleError(error, 'update', refundId);
+        }
+    }
+    async delete(refundId) {
+        try {
+            await this.stateset.request('DELETE', `refunds/${refundId}`);
+        }
+        catch (error) {
+            throw this.handleError(error, 'delete', refundId);
+        }
+    }
+    async processRefund(refundId, refundDate) {
+        try {
+            const response = await this.stateset.request('POST', `refunds/${refundId}/process`, { refund_date: refundDate });
+            return this.mapResponse(response.refund);
+        }
+        catch (error) {
+            throw this.handleError(error, 'processRefund', refundId);
+        }
+    }
+    handleError(error, operation, refundId) {
+        if (error.status === 404)
+            throw new RefundNotFoundError(refundId || 'unknown');
+        if (error.status === 400)
+            throw new RefundValidationError(error.message, error.errors);
+        throw new RefundError(`Failed to ${operation} refund: ${error.message}`, { operation, originalError: error });
+    }
+}
+exports.default = Refunds;

--- a/dist/lib/resources/ResourceUtilization.d.ts
+++ b/dist/lib/resources/ResourceUtilization.d.ts
@@ -1,0 +1,82 @@
+import { stateset } from '../../stateset-client';
+type NonEmptyString<T extends string> = T extends '' ? never : T;
+type Timestamp = string;
+export declare enum ResourceUtilizationStatus {
+    AVAILABLE = "AVAILABLE",
+    IN_USE = "IN_USE",
+    MAINTENANCE = "MAINTENANCE",
+    RESERVED = "RESERVED"
+}
+export declare enum ResourceCategory {
+    WAREHOUSE = "WAREHOUSE",
+    MANUFACTURING = "MANUFACTURING",
+    STAFFING = "STAFFING"
+}
+export interface ResourceUtilizationData {
+    resource_id: NonEmptyString<string>;
+    category: ResourceCategory;
+    status: ResourceUtilizationStatus;
+    utilization_start: Timestamp;
+    utilization_end?: Timestamp;
+    warehouse_id?: NonEmptyString<string>;
+    manufacture_order_id?: NonEmptyString<string>;
+    employee_id?: NonEmptyString<string>;
+    capacity: number;
+    utilized_capacity: number;
+    efficiency: number;
+    notes?: string[];
+    created_at: Timestamp;
+    updated_at: Timestamp;
+    org_id?: string;
+    metadata?: Record<string, any>;
+}
+export interface ResourceUtilizationResponse {
+    id: NonEmptyString<string>;
+    object: 'resource_utilization';
+    data: ResourceUtilizationData;
+}
+export declare class ResourceUtilizationError extends Error {
+    readonly details?: Record<string, unknown> | undefined;
+    constructor(message: string, details?: Record<string, unknown> | undefined);
+}
+export declare class ResourceUtilizationNotFoundError extends ResourceUtilizationError {
+    constructor(resourceUtilizationId: string);
+}
+export declare class ResourceUtilizationValidationError extends ResourceUtilizationError {
+    readonly errors?: Record<string, string> | undefined;
+    constructor(message: string, errors?: Record<string, string> | undefined);
+}
+export default class ResourceUtilization {
+    private readonly stateset;
+    constructor(stateset: stateset);
+    private validateResourceUtilizationData;
+    private mapResponse;
+    list(params?: {
+        resource_id?: string;
+        category?: ResourceCategory;
+        status?: ResourceUtilizationStatus;
+        org_id?: string;
+        date_from?: Date;
+        date_to?: Date;
+        limit?: number;
+        offset?: number;
+    }): Promise<{
+        resource_utilizations: ResourceUtilizationResponse[];
+        pagination: {
+            total: number;
+            limit: number;
+            offset: number;
+        };
+    }>;
+    get(resourceUtilizationId: NonEmptyString<string>): Promise<ResourceUtilizationResponse>;
+    create(data: ResourceUtilizationData): Promise<ResourceUtilizationResponse>;
+    update(resourceUtilizationId: NonEmptyString<string>, data: Partial<ResourceUtilizationData>): Promise<ResourceUtilizationResponse>;
+    delete(resourceUtilizationId: NonEmptyString<string>): Promise<void>;
+    updateUtilization(resourceUtilizationId: NonEmptyString<string>, utilizationData: {
+        utilized_capacity: number;
+        efficiency: number;
+        utilization_end?: Timestamp;
+    }): Promise<ResourceUtilizationResponse>;
+    private handleError;
+}
+export {};

--- a/dist/lib/resources/ResourceUtilization.js
+++ b/dist/lib/resources/ResourceUtilization.js
@@ -1,0 +1,170 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ResourceUtilizationValidationError = exports.ResourceUtilizationNotFoundError = exports.ResourceUtilizationError = exports.ResourceCategory = exports.ResourceUtilizationStatus = void 0;
+// Enums
+var ResourceUtilizationStatus;
+(function (ResourceUtilizationStatus) {
+    ResourceUtilizationStatus["AVAILABLE"] = "AVAILABLE";
+    ResourceUtilizationStatus["IN_USE"] = "IN_USE";
+    ResourceUtilizationStatus["MAINTENANCE"] = "MAINTENANCE";
+    ResourceUtilizationStatus["RESERVED"] = "RESERVED";
+})(ResourceUtilizationStatus = exports.ResourceUtilizationStatus || (exports.ResourceUtilizationStatus = {}));
+var ResourceCategory;
+(function (ResourceCategory) {
+    ResourceCategory["WAREHOUSE"] = "WAREHOUSE";
+    ResourceCategory["MANUFACTURING"] = "MANUFACTURING";
+    ResourceCategory["STAFFING"] = "STAFFING";
+})(ResourceCategory = exports.ResourceCategory || (exports.ResourceCategory = {}));
+// Error Classes
+class ResourceUtilizationError extends Error {
+    constructor(message, details) {
+        super(message);
+        this.details = details;
+        this.name = 'ResourceUtilizationError';
+    }
+}
+exports.ResourceUtilizationError = ResourceUtilizationError;
+class ResourceUtilizationNotFoundError extends ResourceUtilizationError {
+    constructor(resourceUtilizationId) {
+        super(`Resource utilization with ID ${resourceUtilizationId} not found`, { resourceUtilizationId });
+    }
+}
+exports.ResourceUtilizationNotFoundError = ResourceUtilizationNotFoundError;
+class ResourceUtilizationValidationError extends ResourceUtilizationError {
+    constructor(message, errors) {
+        super(message);
+        this.errors = errors;
+    }
+}
+exports.ResourceUtilizationValidationError = ResourceUtilizationValidationError;
+class ResourceUtilization {
+    constructor(stateset) {
+        this.stateset = stateset;
+    }
+    validateResourceUtilizationData(data) {
+        if (!data.resource_id)
+            throw new ResourceUtilizationValidationError('Resource ID is required');
+        if (!data.utilization_start)
+            throw new ResourceUtilizationValidationError('Utilization start date is required');
+        if (data.capacity < 0)
+            throw new ResourceUtilizationValidationError('Capacity cannot be negative');
+        if (data.utilized_capacity < 0)
+            throw new ResourceUtilizationValidationError('Utilized capacity cannot be negative');
+        if (data.efficiency < 0 || data.efficiency > 100)
+            throw new ResourceUtilizationValidationError('Efficiency must be between 0 and 100');
+    }
+    mapResponse(data) {
+        if (!(data === null || data === void 0 ? void 0 : data.id))
+            throw new ResourceUtilizationError('Invalid response format');
+        return {
+            id: data.id,
+            object: 'resource_utilization',
+            data: {
+                resource_id: data.resource_id,
+                category: data.category,
+                status: data.status,
+                utilization_start: data.utilization_start,
+                utilization_end: data.utilization_end,
+                warehouse_id: data.warehouse_id,
+                manufacture_order_id: data.manufacture_order_id,
+                employee_id: data.employee_id,
+                capacity: data.capacity,
+                utilized_capacity: data.utilized_capacity,
+                efficiency: data.efficiency,
+                notes: data.notes,
+                created_at: data.created_at,
+                updated_at: data.updated_at,
+                org_id: data.org_id,
+                metadata: data.metadata,
+            },
+        };
+    }
+    async list(params) {
+        const queryParams = new URLSearchParams();
+        if (params) {
+            if (params.resource_id)
+                queryParams.append('resource_id', params.resource_id);
+            if (params.category)
+                queryParams.append('category', params.category);
+            if (params.status)
+                queryParams.append('status', params.status);
+            if (params.org_id)
+                queryParams.append('org_id', params.org_id);
+            if (params.date_from)
+                queryParams.append('date_from', params.date_from.toISOString());
+            if (params.date_to)
+                queryParams.append('date_to', params.date_to.toISOString());
+            if (params.limit)
+                queryParams.append('limit', params.limit.toString());
+            if (params.offset)
+                queryParams.append('offset', params.offset.toString());
+        }
+        try {
+            const response = await this.stateset.request('GET', `resource_utilizations?${queryParams.toString()}`);
+            return {
+                resource_utilizations: response.resource_utilizations.map(this.mapResponse),
+                pagination: {
+                    total: response.total || response.resource_utilizations.length,
+                    limit: (params === null || params === void 0 ? void 0 : params.limit) || 100,
+                    offset: (params === null || params === void 0 ? void 0 : params.offset) || 0,
+                },
+            };
+        }
+        catch (error) {
+            throw this.handleError(error, 'list');
+        }
+    }
+    async get(resourceUtilizationId) {
+        try {
+            const response = await this.stateset.request('GET', `resource_utilizations/${resourceUtilizationId}`);
+            return this.mapResponse(response.resource_utilization);
+        }
+        catch (error) {
+            throw this.handleError(error, 'get', resourceUtilizationId);
+        }
+    }
+    async create(data) {
+        this.validateResourceUtilizationData(data);
+        try {
+            const response = await this.stateset.request('POST', 'resource_utilizations', data);
+            return this.mapResponse(response.resource_utilization);
+        }
+        catch (error) {
+            throw this.handleError(error, 'create');
+        }
+    }
+    async update(resourceUtilizationId, data) {
+        try {
+            const response = await this.stateset.request('PUT', `resource_utilizations/${resourceUtilizationId}`, data);
+            return this.mapResponse(response.resource_utilization);
+        }
+        catch (error) {
+            throw this.handleError(error, 'update', resourceUtilizationId);
+        }
+    }
+    async delete(resourceUtilizationId) {
+        try {
+            await this.stateset.request('DELETE', `resource_utilizations/${resourceUtilizationId}`);
+        }
+        catch (error) {
+            throw this.handleError(error, 'delete', resourceUtilizationId);
+        }
+    }
+    async updateUtilization(resourceUtilizationId, utilizationData) {
+        try {
+            const response = await this.stateset.request('POST', `resource_utilizations/${resourceUtilizationId}/utilization`, utilizationData);
+            return this.mapResponse(response.resource_utilization);
+        }
+        catch (error) {
+            throw this.handleError(error, 'updateUtilization', resourceUtilizationId);
+        }
+    }
+    handleError(error, operation, resourceUtilizationId) {
+        if (error.status === 404)
+            throw new ResourceUtilizationNotFoundError(resourceUtilizationId || 'unknown');
+        if (error.status === 400)
+            throw new ResourceUtilizationValidationError(error.message, error.errors);
+        throw new ResourceUtilizationError(`Failed to ${operation} resource utilization: ${error.message}`, { operation, originalError: error });
+    }
+}
+exports.default = ResourceUtilization;

--- a/dist/lib/resources/Response.d.ts
+++ b/dist/lib/resources/Response.d.ts
@@ -1,0 +1,64 @@
+import { stateset } from '../../stateset-client';
+export declare enum ResponseType {
+    TEXT = "text",
+    ACTION = "action",
+    ERROR = "error",
+    SYSTEM = "system"
+}
+export declare enum ResponseStatus {
+    PENDING = "pending",
+    SENT = "sent",
+    FAILED = "failed"
+}
+export interface ResponseData {
+    content: string;
+    type: ResponseType;
+    status?: ResponseStatus;
+    metadata?: Record<string, any>;
+    agent_id?: string;
+    user_id?: string;
+    org_id?: string;
+}
+export interface AgentResponseRecord {
+    id: string;
+    created_at: string;
+    updated_at: string;
+    data: ResponseData;
+}
+export declare class ResponseNotFoundError extends Error {
+    constructor(responseId: string);
+}
+export declare class ResponseValidationError extends Error {
+    constructor(message: string);
+}
+declare class Responses {
+    private readonly stateset;
+    constructor(stateset: stateset);
+    /**
+     * List responses with optional filtering
+     */
+    list(params?: {
+        agent_id?: string;
+        user_id?: string;
+        org_id?: string;
+        status?: ResponseStatus;
+        type?: ResponseType;
+    }): Promise<AgentResponseRecord[]>;
+    /**
+     * Get a specific response
+     */
+    get(responseId: string): Promise<AgentResponseRecord>;
+    /**
+     * Create a new response
+     */
+    create(data: ResponseData): Promise<AgentResponseRecord>;
+    /**
+     * Update an existing response
+     */
+    update(responseId: string, data: Partial<ResponseData>): Promise<AgentResponseRecord>;
+    /**
+     * Delete a response
+     */
+    delete(responseId: string): Promise<void>;
+}
+export default Responses;

--- a/dist/lib/resources/Response.js
+++ b/dist/lib/resources/Response.js
@@ -1,0 +1,114 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ResponseValidationError = exports.ResponseNotFoundError = exports.ResponseStatus = exports.ResponseType = void 0;
+// Enums for response management
+var ResponseType;
+(function (ResponseType) {
+    ResponseType["TEXT"] = "text";
+    ResponseType["ACTION"] = "action";
+    ResponseType["ERROR"] = "error";
+    ResponseType["SYSTEM"] = "system";
+})(ResponseType = exports.ResponseType || (exports.ResponseType = {}));
+var ResponseStatus;
+(function (ResponseStatus) {
+    ResponseStatus["PENDING"] = "pending";
+    ResponseStatus["SENT"] = "sent";
+    ResponseStatus["FAILED"] = "failed";
+})(ResponseStatus = exports.ResponseStatus || (exports.ResponseStatus = {}));
+// Custom error classes
+class ResponseNotFoundError extends Error {
+    constructor(responseId) {
+        super(`Response with ID ${responseId} not found`);
+        this.name = 'ResponseNotFoundError';
+    }
+}
+exports.ResponseNotFoundError = ResponseNotFoundError;
+class ResponseValidationError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'ResponseValidationError';
+    }
+}
+exports.ResponseValidationError = ResponseValidationError;
+// Main Responses class
+class Responses {
+    constructor(stateset) {
+        this.stateset = stateset;
+    }
+    /**
+     * List responses with optional filtering
+     */
+    async list(params) {
+        const queryParams = new URLSearchParams();
+        if (params === null || params === void 0 ? void 0 : params.agent_id)
+            queryParams.append('agent_id', params.agent_id);
+        if (params === null || params === void 0 ? void 0 : params.user_id)
+            queryParams.append('user_id', params.user_id);
+        if (params === null || params === void 0 ? void 0 : params.org_id)
+            queryParams.append('org_id', params.org_id);
+        if (params === null || params === void 0 ? void 0 : params.status)
+            queryParams.append('status', params.status);
+        if (params === null || params === void 0 ? void 0 : params.type)
+            queryParams.append('type', params.type);
+        const response = await this.stateset.request('GET', `responses?${queryParams.toString()}`);
+        return response.responses;
+    }
+    /**
+     * Get a specific response
+     */
+    async get(responseId) {
+        try {
+            const response = await this.stateset.request('GET', `responses/${responseId}`);
+            return response.response;
+        }
+        catch (error) {
+            if (error.status === 404) {
+                throw new ResponseNotFoundError(responseId);
+            }
+            throw error;
+        }
+    }
+    /**
+     * Create a new response
+     */
+    async create(data) {
+        if (!data.content) {
+            throw new ResponseValidationError('Response content is required');
+        }
+        if (!data.type) {
+            throw new ResponseValidationError('Response type is required');
+        }
+        const response = await this.stateset.request('POST', 'responses', data);
+        return response.response;
+    }
+    /**
+     * Update an existing response
+     */
+    async update(responseId, data) {
+        try {
+            const response = await this.stateset.request('PUT', `responses/${responseId}`, data);
+            return response.response;
+        }
+        catch (error) {
+            if (error.status === 404) {
+                throw new ResponseNotFoundError(responseId);
+            }
+            throw error;
+        }
+    }
+    /**
+     * Delete a response
+     */
+    async delete(responseId) {
+        try {
+            await this.stateset.request('DELETE', `responses/${responseId}`);
+        }
+        catch (error) {
+            if (error.status === 404) {
+                throw new ResponseNotFoundError(responseId);
+            }
+            throw error;
+        }
+    }
+}
+exports.default = Responses;

--- a/dist/lib/resources/Route.d.ts
+++ b/dist/lib/resources/Route.d.ts
@@ -1,0 +1,92 @@
+import { stateset } from '../../stateset-client';
+type NonEmptyString<T extends string> = T extends '' ? never : T;
+type Timestamp = string;
+export declare enum RouteStatus {
+    PLANNED = "PLANNED",
+    IN_PROGRESS = "IN_PROGRESS",
+    COMPLETED = "COMPLETED",
+    CANCELLED = "CANCELLED"
+}
+export interface RouteData {
+    carrier_id: NonEmptyString<string>;
+    status: RouteStatus;
+    start_location: {
+        warehouse_id?: string;
+        address: {
+            line1: string;
+            city: string;
+            state: string;
+            postal_code: string;
+            country: string;
+        };
+    };
+    end_location: {
+        customer_id?: string;
+        address: {
+            line1: string;
+            city: string;
+            state: string;
+            postal_code: string;
+            country: string;
+        };
+    };
+    shipment_ids: NonEmptyString<string>[];
+    estimated_distance: number;
+    actual_distance?: number;
+    estimated_duration: number;
+    actual_duration?: number;
+    cost_estimate: number;
+    actual_cost?: number;
+    currency: string;
+    start_time: Timestamp;
+    end_time?: Timestamp;
+    created_at: Timestamp;
+    updated_at: Timestamp;
+    org_id?: string;
+    metadata?: Record<string, any>;
+}
+export interface RouteResponse {
+    id: NonEmptyString<string>;
+    object: 'route';
+    data: RouteData;
+}
+export declare class RouteError extends Error {
+    readonly details?: Record<string, unknown> | undefined;
+    constructor(message: string, details?: Record<string, unknown> | undefined);
+}
+export declare class RouteNotFoundError extends RouteError {
+    constructor(routeId: string);
+}
+export declare class RouteValidationError extends RouteError {
+    readonly errors?: Record<string, string> | undefined;
+    constructor(message: string, errors?: Record<string, string> | undefined);
+}
+export default class Routes {
+    private readonly stateset;
+    constructor(stateset: stateset);
+    private validateRouteData;
+    private mapResponse;
+    list(params?: {
+        carrier_id?: string;
+        status?: RouteStatus;
+        org_id?: string;
+        date_from?: Date;
+        date_to?: Date;
+        limit?: number;
+        offset?: number;
+    }): Promise<{
+        routes: RouteResponse[];
+        pagination: {
+            total: number;
+            limit: number;
+            offset: number;
+        };
+    }>;
+    get(routeId: NonEmptyString<string>): Promise<RouteResponse>;
+    create(data: RouteData): Promise<RouteResponse>;
+    update(routeId: NonEmptyString<string>, data: Partial<RouteData>): Promise<RouteResponse>;
+    delete(routeId: NonEmptyString<string>): Promise<void>;
+    optimizeRoute(routeId: NonEmptyString<string>): Promise<RouteResponse>;
+    private handleError;
+}
+export {};

--- a/dist/lib/resources/Route.js
+++ b/dist/lib/resources/Route.js
@@ -1,0 +1,169 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.RouteValidationError = exports.RouteNotFoundError = exports.RouteError = exports.RouteStatus = void 0;
+// Enums
+var RouteStatus;
+(function (RouteStatus) {
+    RouteStatus["PLANNED"] = "PLANNED";
+    RouteStatus["IN_PROGRESS"] = "IN_PROGRESS";
+    RouteStatus["COMPLETED"] = "COMPLETED";
+    RouteStatus["CANCELLED"] = "CANCELLED";
+})(RouteStatus = exports.RouteStatus || (exports.RouteStatus = {}));
+// Error Classes
+class RouteError extends Error {
+    constructor(message, details) {
+        super(message);
+        this.details = details;
+        this.name = 'RouteError';
+    }
+}
+exports.RouteError = RouteError;
+class RouteNotFoundError extends RouteError {
+    constructor(routeId) {
+        super(`Route with ID ${routeId} not found`, { routeId });
+    }
+}
+exports.RouteNotFoundError = RouteNotFoundError;
+class RouteValidationError extends RouteError {
+    constructor(message, errors) {
+        super(message);
+        this.errors = errors;
+    }
+}
+exports.RouteValidationError = RouteValidationError;
+class Routes {
+    constructor(stateset) {
+        this.stateset = stateset;
+    }
+    validateRouteData(data) {
+        var _a;
+        if (!data.carrier_id)
+            throw new RouteValidationError('Carrier ID is required');
+        if (!data.start_location.address.line1)
+            throw new RouteValidationError('Start location address is required');
+        if (!data.end_location.address.line1)
+            throw new RouteValidationError('End location address is required');
+        if (!((_a = data.shipment_ids) === null || _a === void 0 ? void 0 : _a.length))
+            throw new RouteValidationError('At least one shipment ID is required');
+        if (data.estimated_distance < 0)
+            throw new RouteValidationError('Estimated distance cannot be negative');
+        if (data.estimated_duration < 0)
+            throw new RouteValidationError('Estimated duration cannot be negative');
+        if (data.cost_estimate < 0)
+            throw new RouteValidationError('Cost estimate cannot be negative');
+    }
+    mapResponse(data) {
+        if (!(data === null || data === void 0 ? void 0 : data.id))
+            throw new RouteError('Invalid response format');
+        return {
+            id: data.id,
+            object: 'route',
+            data: {
+                carrier_id: data.carrier_id,
+                status: data.status,
+                start_location: data.start_location,
+                end_location: data.end_location,
+                shipment_ids: data.shipment_ids,
+                estimated_distance: data.estimated_distance,
+                actual_distance: data.actual_distance,
+                estimated_duration: data.estimated_duration,
+                actual_duration: data.actual_duration,
+                cost_estimate: data.cost_estimate,
+                actual_cost: data.actual_cost,
+                currency: data.currency,
+                start_time: data.start_time,
+                end_time: data.end_time,
+                created_at: data.created_at,
+                updated_at: data.updated_at,
+                org_id: data.org_id,
+                metadata: data.metadata,
+            },
+        };
+    }
+    async list(params) {
+        const queryParams = new URLSearchParams();
+        if (params) {
+            if (params.carrier_id)
+                queryParams.append('carrier_id', params.carrier_id);
+            if (params.status)
+                queryParams.append('status', params.status);
+            if (params.org_id)
+                queryParams.append('org_id', params.org_id);
+            if (params.date_from)
+                queryParams.append('date_from', params.date_from.toISOString());
+            if (params.date_to)
+                queryParams.append('date_to', params.date_to.toISOString());
+            if (params.limit)
+                queryParams.append('limit', params.limit.toString());
+            if (params.offset)
+                queryParams.append('offset', params.offset.toString());
+        }
+        try {
+            const response = await this.stateset.request('GET', `routes?${queryParams.toString()}`);
+            return {
+                routes: response.routes.map(this.mapResponse),
+                pagination: {
+                    total: response.total || response.routes.length,
+                    limit: (params === null || params === void 0 ? void 0 : params.limit) || 100,
+                    offset: (params === null || params === void 0 ? void 0 : params.offset) || 0,
+                },
+            };
+        }
+        catch (error) {
+            throw this.handleError(error, 'list');
+        }
+    }
+    async get(routeId) {
+        try {
+            const response = await this.stateset.request('GET', `routes/${routeId}`);
+            return this.mapResponse(response.route);
+        }
+        catch (error) {
+            throw this.handleError(error, 'get', routeId);
+        }
+    }
+    async create(data) {
+        this.validateRouteData(data);
+        try {
+            const response = await this.stateset.request('POST', 'routes', data);
+            return this.mapResponse(response.route);
+        }
+        catch (error) {
+            throw this.handleError(error, 'create');
+        }
+    }
+    async update(routeId, data) {
+        try {
+            const response = await this.stateset.request('PUT', `routes/${routeId}`, data);
+            return this.mapResponse(response.route);
+        }
+        catch (error) {
+            throw this.handleError(error, 'update', routeId);
+        }
+    }
+    async delete(routeId) {
+        try {
+            await this.stateset.request('DELETE', `routes/${routeId}`);
+        }
+        catch (error) {
+            throw this.handleError(error, 'delete', routeId);
+        }
+    }
+    async optimizeRoute(routeId) {
+        try {
+            const response = await this.stateset.request('POST', `routes/${routeId}/optimize`, {});
+            return this.mapResponse(response.route);
+        }
+        catch (error) {
+            throw this.handleError(error, 'optimizeRoute', routeId);
+        }
+    }
+    handleError(error, operation, routeId) {
+        if (error.status === 404)
+            throw new RouteNotFoundError(routeId || 'unknown');
+        if (error.status === 400)
+            throw new RouteValidationError(error.message, error.errors);
+        throw new RouteError(`Failed to ${operation} route: ${error.message}`, { operation, originalError: error });
+    }
+}
+exports.default = Routes;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 import { stateset } from './stateset-client';
+import OpenAIIntegration from './lib/integrations/OpenAIIntegration';
 
 export default stateset;
+export { OpenAIIntegration };

--- a/src/lib/integrations/OpenAIIntegration.ts
+++ b/src/lib/integrations/OpenAIIntegration.ts
@@ -1,0 +1,53 @@
+import axios, { AxiosInstance } from 'axios';
+
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface ChatCompletionOptions {
+  model?: string;
+  temperature?: number;
+  max_tokens?: number;
+}
+
+export interface ChatCompletionResponseChoice {
+  index: number;
+  message: ChatMessage;
+  finish_reason: string;
+}
+
+export interface ChatCompletionResponse {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: ChatCompletionResponseChoice[];
+}
+
+export default class OpenAIIntegration {
+  private client: AxiosInstance;
+
+  constructor(apiKey: string, baseUrl: string = 'https://api.openai.com/v1') {
+    this.client = axios.create({
+      baseURL: baseUrl,
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json'
+      }
+    });
+  }
+
+  async createChatCompletion(
+    messages: ChatMessage[],
+    options: ChatCompletionOptions = {}
+  ): Promise<ChatCompletionResponse> {
+    const data = {
+      model: options.model || 'gpt-3.5-turbo',
+      messages,
+      ...options
+    };
+    const resp = await this.client.post('/chat/completions', data);
+    return resp.data;
+  }
+}


### PR DESCRIPTION
## Summary
- expose a new `OpenAIIntegration` class for interacting with OpenAI's chat completion API
- export the integration from the main package index
- document OpenAI capabilities in README and add example usage
- create test coverage for the new integration
- update dist with compiled artifacts for newly exposed resources

## Testing
- `npm run build`
- `npm test`
