### PR TITLE
Add missing commerce resources

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -94,3 +94,11 @@ test('Shipments.generateLabel sends request', async () => {
   expect(mock).toHaveBeenCalledWith('POST', 'shipments/ship_1/label', { format: 'PDF' });
   expect(res.label_url).toBe('url');
 });
+
+test('exposes newly added commerce resources', () => {
+  const client: any = new stateset({ apiKey: 'k' });
+  expect(typeof client.salesOrders.list).toBe('function');
+  expect(typeof client.fulfillmentOrders.list).toBe('function');
+  expect(typeof client.itemReceipts.list).toBe('function');
+  expect(typeof client.cashSales.list).toBe('function');
+});

--- a/src/lib/resources/CashSale.ts
+++ b/src/lib/resources/CashSale.ts
@@ -1,0 +1,132 @@
+import { stateset } from '../../stateset-client';
+
+export type CashSaleStatus = 'PENDING' | 'COMPLETED' | 'CANCELLED' | 'REFUNDED';
+
+interface BaseCashSaleResponse {
+  id: string;
+  object: 'cashsale';
+  status: CashSaleStatus;
+}
+
+interface PendingCashSaleResponse extends BaseCashSaleResponse {
+  status: 'PENDING';
+  pending: true;
+}
+interface CompletedCashSaleResponse extends BaseCashSaleResponse {
+  status: 'COMPLETED';
+  completed: true;
+}
+interface CancelledCashSaleResponse extends BaseCashSaleResponse {
+  status: 'CANCELLED';
+  cancelled: true;
+}
+interface RefundedCashSaleResponse extends BaseCashSaleResponse {
+  status: 'REFUNDED';
+  refunded: true;
+}
+
+export type CashSaleResponse =
+  | PendingCashSaleResponse
+  | CompletedCashSaleResponse
+  | CancelledCashSaleResponse
+  | RefundedCashSaleResponse;
+
+interface ApiResponse {
+  update_cashsales_by_pk: {
+    id: string;
+    status: CashSaleStatus;
+    [key: string]: any;
+  };
+}
+
+export interface CashSaleLine {
+  item_id: string;
+  quantity: number;
+  unit_price: number;
+  [key: string]: any;
+}
+
+export interface CashSaleData {
+  customer_id: string;
+  sale_date: string;
+  lines: CashSaleLine[];
+  [key: string]: any;
+}
+
+class CashSales {
+  constructor(private stateset: stateset) {}
+
+  private handleCommandResponse(response: any): CashSaleResponse {
+    if (response.error) {
+      throw new Error(response.error);
+    }
+
+    if (!response.update_cashsales_by_pk) {
+      throw new Error('Unexpected response format');
+    }
+
+    const sale = response.update_cashsales_by_pk;
+
+    const base: BaseCashSaleResponse = {
+      id: sale.id,
+      object: 'cashsale',
+      status: sale.status,
+    };
+
+    switch (sale.status) {
+      case 'PENDING':
+        return { ...base, status: 'PENDING', pending: true };
+      case 'COMPLETED':
+        return { ...base, status: 'COMPLETED', completed: true };
+      case 'CANCELLED':
+        return { ...base, status: 'CANCELLED', cancelled: true };
+      case 'REFUNDED':
+        return { ...base, status: 'REFUNDED', refunded: true };
+      default:
+        throw new Error(`Unexpected cash sale status: ${sale.status}`);
+    }
+  }
+
+  async list(): Promise<CashSaleResponse[]> {
+    const response = await this.stateset.request('GET', 'cashsales');
+    return response.map((cs: any) =>
+      this.handleCommandResponse({ update_cashsales_by_pk: cs })
+    );
+  }
+
+  async get(id: string): Promise<CashSaleResponse> {
+    const response = await this.stateset.request('GET', `cashsales/${id}`);
+    return this.handleCommandResponse({ update_cashsales_by_pk: response });
+  }
+
+  async create(data: CashSaleData): Promise<CashSaleResponse> {
+    const response = await this.stateset.request('POST', 'cashsales', data);
+    return this.handleCommandResponse(response);
+  }
+
+  async update(id: string, data: Partial<CashSaleData>): Promise<CashSaleResponse> {
+    const response = await this.stateset.request('PUT', `cashsales/${id}`, data);
+    return this.handleCommandResponse(response);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.stateset.request('DELETE', `cashsales/${id}`);
+  }
+
+  async complete(id: string): Promise<CompletedCashSaleResponse> {
+    const response = await this.stateset.request('POST', `cashsales/${id}/complete`);
+    return this.handleCommandResponse(response) as CompletedCashSaleResponse;
+  }
+
+  async refund(id: string): Promise<RefundedCashSaleResponse> {
+    const response = await this.stateset.request('POST', `cashsales/${id}/refund`);
+    return this.handleCommandResponse(response) as RefundedCashSaleResponse;
+  }
+
+  async cancel(id: string): Promise<CancelledCashSaleResponse> {
+    const response = await this.stateset.request('POST', `cashsales/${id}/cancel`);
+    return this.handleCommandResponse(response) as CancelledCashSaleResponse;
+  }
+}
+
+export default CashSales;

--- a/src/lib/resources/FulfillmentOrder.ts
+++ b/src/lib/resources/FulfillmentOrder.ts
@@ -1,0 +1,161 @@
+import { stateset } from '../../stateset-client';
+
+export type FulfillmentOrderStatus =
+  | 'OPEN'
+  | 'ALLOCATED'
+  | 'PICKED'
+  | 'PACKED'
+  | 'SHIPPED'
+  | 'CANCELLED';
+
+interface BaseFulfillmentOrderResponse {
+  id: string;
+  object: 'fulfillmentorder';
+  status: FulfillmentOrderStatus;
+}
+
+interface OpenFulfillmentOrderResponse extends BaseFulfillmentOrderResponse {
+  status: 'OPEN';
+  open: true;
+}
+interface AllocatedFulfillmentOrderResponse extends BaseFulfillmentOrderResponse {
+  status: 'ALLOCATED';
+  allocated: true;
+}
+interface PickedFulfillmentOrderResponse extends BaseFulfillmentOrderResponse {
+  status: 'PICKED';
+  picked: true;
+}
+interface PackedFulfillmentOrderResponse extends BaseFulfillmentOrderResponse {
+  status: 'PACKED';
+  packed: true;
+}
+interface ShippedFulfillmentOrderResponse extends BaseFulfillmentOrderResponse {
+  status: 'SHIPPED';
+  shipped: true;
+}
+interface CancelledFulfillmentOrderResponse extends BaseFulfillmentOrderResponse {
+  status: 'CANCELLED';
+  cancelled: true;
+}
+
+export type FulfillmentOrderResponse =
+  | OpenFulfillmentOrderResponse
+  | AllocatedFulfillmentOrderResponse
+  | PickedFulfillmentOrderResponse
+  | PackedFulfillmentOrderResponse
+  | ShippedFulfillmentOrderResponse
+  | CancelledFulfillmentOrderResponse;
+
+interface ApiResponse {
+  update_fulfillmentorders_by_pk: {
+    id: string;
+    status: FulfillmentOrderStatus;
+    [key: string]: any;
+  };
+}
+
+export interface FulfillmentOrderLine {
+  item_id: string;
+  quantity: number;
+  [key: string]: any;
+}
+
+export interface FulfillmentOrderData {
+  order_id: string;
+  warehouse_id: string;
+  lines: FulfillmentOrderLine[];
+  [key: string]: any;
+}
+
+class FulfillmentOrders {
+  constructor(private stateset: stateset) {}
+
+  private handleCommandResponse(response: any): FulfillmentOrderResponse {
+    if (response.error) {
+      throw new Error(response.error);
+    }
+
+    if (!response.update_fulfillmentorders_by_pk) {
+      throw new Error('Unexpected response format');
+    }
+
+    const fo = response.update_fulfillmentorders_by_pk;
+
+    const base: BaseFulfillmentOrderResponse = {
+      id: fo.id,
+      object: 'fulfillmentorder',
+      status: fo.status,
+    };
+
+    switch (fo.status) {
+      case 'OPEN':
+        return { ...base, status: 'OPEN', open: true };
+      case 'ALLOCATED':
+        return { ...base, status: 'ALLOCATED', allocated: true };
+      case 'PICKED':
+        return { ...base, status: 'PICKED', picked: true };
+      case 'PACKED':
+        return { ...base, status: 'PACKED', packed: true };
+      case 'SHIPPED':
+        return { ...base, status: 'SHIPPED', shipped: true };
+      case 'CANCELLED':
+        return { ...base, status: 'CANCELLED', cancelled: true };
+      default:
+        throw new Error(`Unexpected fulfillment order status: ${fo.status}`);
+    }
+  }
+
+  async list(): Promise<FulfillmentOrderResponse[]> {
+    const response = await this.stateset.request('GET', 'fulfillmentorders');
+    return response.map((fo: any) =>
+      this.handleCommandResponse({ update_fulfillmentorders_by_pk: fo })
+    );
+  }
+
+  async get(id: string): Promise<FulfillmentOrderResponse> {
+    const response = await this.stateset.request('GET', `fulfillmentorders/${id}`);
+    return this.handleCommandResponse({ update_fulfillmentorders_by_pk: response });
+  }
+
+  async create(data: FulfillmentOrderData): Promise<FulfillmentOrderResponse> {
+    const response = await this.stateset.request('POST', 'fulfillmentorders', data);
+    return this.handleCommandResponse(response);
+  }
+
+  async update(id: string, data: Partial<FulfillmentOrderData>): Promise<FulfillmentOrderResponse> {
+    const response = await this.stateset.request('PUT', `fulfillmentorders/${id}`, data);
+    return this.handleCommandResponse(response);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.stateset.request('DELETE', `fulfillmentorders/${id}`);
+  }
+
+  async allocate(id: string): Promise<AllocatedFulfillmentOrderResponse> {
+    const response = await this.stateset.request('POST', `fulfillmentorders/${id}/allocate`);
+    return this.handleCommandResponse(response) as AllocatedFulfillmentOrderResponse;
+  }
+
+  async pick(id: string): Promise<PickedFulfillmentOrderResponse> {
+    const response = await this.stateset.request('POST', `fulfillmentorders/${id}/pick`);
+    return this.handleCommandResponse(response) as PickedFulfillmentOrderResponse;
+  }
+
+  async pack(id: string): Promise<PackedFulfillmentOrderResponse> {
+    const response = await this.stateset.request('POST', `fulfillmentorders/${id}/pack`);
+    return this.handleCommandResponse(response) as PackedFulfillmentOrderResponse;
+  }
+
+  async ship(id: string): Promise<ShippedFulfillmentOrderResponse> {
+    const response = await this.stateset.request('POST', `fulfillmentorders/${id}/ship`);
+    return this.handleCommandResponse(response) as ShippedFulfillmentOrderResponse;
+  }
+
+  async cancel(id: string): Promise<CancelledFulfillmentOrderResponse> {
+    const response = await this.stateset.request('POST', `fulfillmentorders/${id}/cancel`);
+    return this.handleCommandResponse(response) as CancelledFulfillmentOrderResponse;
+  }
+}
+
+export default FulfillmentOrders;

--- a/src/lib/resources/ItemReceipt.ts
+++ b/src/lib/resources/ItemReceipt.ts
@@ -1,0 +1,126 @@
+import { stateset } from '../../stateset-client';
+
+export type ItemReceiptStatus = 'PENDING' | 'RECEIVED' | 'PARTIAL' | 'CANCELLED';
+
+interface BaseItemReceiptResponse {
+  id: string;
+  object: 'itemreceipt';
+  status: ItemReceiptStatus;
+}
+
+interface PendingItemReceiptResponse extends BaseItemReceiptResponse {
+  status: 'PENDING';
+  pending: true;
+}
+interface ReceivedItemReceiptResponse extends BaseItemReceiptResponse {
+  status: 'RECEIVED';
+  received: true;
+}
+interface PartialItemReceiptResponse extends BaseItemReceiptResponse {
+  status: 'PARTIAL';
+  partial: true;
+}
+interface CancelledItemReceiptResponse extends BaseItemReceiptResponse {
+  status: 'CANCELLED';
+  cancelled: true;
+}
+
+export type ItemReceiptResponse =
+  | PendingItemReceiptResponse
+  | ReceivedItemReceiptResponse
+  | PartialItemReceiptResponse
+  | CancelledItemReceiptResponse;
+
+interface ApiResponse {
+  update_itemreceipts_by_pk: {
+    id: string;
+    status: ItemReceiptStatus;
+    [key: string]: any;
+  };
+}
+
+export interface ItemReceiptLine {
+  item_id: string;
+  quantity_received: number;
+  [key: string]: any;
+}
+
+export interface ItemReceiptData {
+  purchase_order_id: string;
+  lines: ItemReceiptLine[];
+  receipt_date: string;
+  [key: string]: any;
+}
+
+class ItemReceipts {
+  constructor(private stateset: stateset) {}
+
+  private handleCommandResponse(response: any): ItemReceiptResponse {
+    if (response.error) {
+      throw new Error(response.error);
+    }
+
+    if (!response.update_itemreceipts_by_pk) {
+      throw new Error('Unexpected response format');
+    }
+
+    const rec = response.update_itemreceipts_by_pk;
+
+    const base: BaseItemReceiptResponse = {
+      id: rec.id,
+      object: 'itemreceipt',
+      status: rec.status,
+    };
+
+    switch (rec.status) {
+      case 'PENDING':
+        return { ...base, status: 'PENDING', pending: true };
+      case 'RECEIVED':
+        return { ...base, status: 'RECEIVED', received: true };
+      case 'PARTIAL':
+        return { ...base, status: 'PARTIAL', partial: true };
+      case 'CANCELLED':
+        return { ...base, status: 'CANCELLED', cancelled: true };
+      default:
+        throw new Error(`Unexpected item receipt status: ${rec.status}`);
+    }
+  }
+
+  async list(): Promise<ItemReceiptResponse[]> {
+    const response = await this.stateset.request('GET', 'itemreceipts');
+    return response.map((r: any) =>
+      this.handleCommandResponse({ update_itemreceipts_by_pk: r })
+    );
+  }
+
+  async get(id: string): Promise<ItemReceiptResponse> {
+    const response = await this.stateset.request('GET', `itemreceipts/${id}`);
+    return this.handleCommandResponse({ update_itemreceipts_by_pk: response });
+  }
+
+  async create(data: ItemReceiptData): Promise<ItemReceiptResponse> {
+    const response = await this.stateset.request('POST', 'itemreceipts', data);
+    return this.handleCommandResponse(response);
+  }
+
+  async update(id: string, data: Partial<ItemReceiptData>): Promise<ItemReceiptResponse> {
+    const response = await this.stateset.request('PUT', `itemreceipts/${id}`, data);
+    return this.handleCommandResponse(response);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.stateset.request('DELETE', `itemreceipts/${id}`);
+  }
+
+  async receive(id: string): Promise<ReceivedItemReceiptResponse> {
+    const response = await this.stateset.request('POST', `itemreceipts/${id}/receive`);
+    return this.handleCommandResponse(response) as ReceivedItemReceiptResponse;
+  }
+
+  async cancel(id: string): Promise<CancelledItemReceiptResponse> {
+    const response = await this.stateset.request('POST', `itemreceipts/${id}/cancel`);
+    return this.handleCommandResponse(response) as CancelledItemReceiptResponse;
+  }
+}
+
+export default ItemReceipts;

--- a/src/lib/resources/SalesOrder.ts
+++ b/src/lib/resources/SalesOrder.ts
@@ -1,0 +1,162 @@
+import { stateset } from '../../stateset-client';
+
+export type SalesOrderStatus =
+  | 'DRAFT'
+  | 'SUBMITTED'
+  | 'FULFILLED'
+  | 'INVOICED'
+  | 'PAID'
+  | 'CANCELLED';
+
+interface BaseSalesOrderResponse {
+  id: string;
+  object: 'salesorder';
+  status: SalesOrderStatus;
+}
+
+interface DraftSalesOrderResponse extends BaseSalesOrderResponse {
+  status: 'DRAFT';
+  draft: true;
+}
+interface SubmittedSalesOrderResponse extends BaseSalesOrderResponse {
+  status: 'SUBMITTED';
+  submitted: true;
+}
+interface FulfilledSalesOrderResponse extends BaseSalesOrderResponse {
+  status: 'FULFILLED';
+  fulfilled: true;
+}
+interface InvoicedSalesOrderResponse extends BaseSalesOrderResponse {
+  status: 'INVOICED';
+  invoiced: true;
+}
+interface PaidSalesOrderResponse extends BaseSalesOrderResponse {
+  status: 'PAID';
+  paid: true;
+}
+interface CancelledSalesOrderResponse extends BaseSalesOrderResponse {
+  status: 'CANCELLED';
+  cancelled: true;
+}
+
+export type SalesOrderResponse =
+  | DraftSalesOrderResponse
+  | SubmittedSalesOrderResponse
+  | FulfilledSalesOrderResponse
+  | InvoicedSalesOrderResponse
+  | PaidSalesOrderResponse
+  | CancelledSalesOrderResponse;
+
+interface ApiResponse {
+  update_salesorders_by_pk: {
+    id: string;
+    status: SalesOrderStatus;
+    [key: string]: any;
+  };
+}
+
+export interface SalesOrderItem {
+  item_id: string;
+  quantity: number;
+  unit_price: number;
+  [key: string]: any;
+}
+
+export interface SalesOrderData {
+  customer_id: string;
+  order_date: string;
+  items: SalesOrderItem[];
+  [key: string]: any;
+}
+
+class SalesOrders {
+  constructor(private stateset: stateset) {}
+
+  private handleCommandResponse(response: any): SalesOrderResponse {
+    if (response.error) {
+      throw new Error(response.error);
+    }
+
+    if (!response.update_salesorders_by_pk) {
+      throw new Error('Unexpected response format');
+    }
+
+    const salesOrder = response.update_salesorders_by_pk;
+
+    const base: BaseSalesOrderResponse = {
+      id: salesOrder.id,
+      object: 'salesorder',
+      status: salesOrder.status,
+    };
+
+    switch (salesOrder.status) {
+      case 'DRAFT':
+        return { ...base, status: 'DRAFT', draft: true };
+      case 'SUBMITTED':
+        return { ...base, status: 'SUBMITTED', submitted: true };
+      case 'FULFILLED':
+        return { ...base, status: 'FULFILLED', fulfilled: true };
+      case 'INVOICED':
+        return { ...base, status: 'INVOICED', invoiced: true };
+      case 'PAID':
+        return { ...base, status: 'PAID', paid: true };
+      case 'CANCELLED':
+        return { ...base, status: 'CANCELLED', cancelled: true };
+      default:
+        throw new Error(`Unexpected sales order status: ${salesOrder.status}`);
+    }
+  }
+
+  async list(): Promise<SalesOrderResponse[]> {
+    const response = await this.stateset.request('GET', 'salesorders');
+    return response.map((so: any) =>
+      this.handleCommandResponse({ update_salesorders_by_pk: so })
+    );
+  }
+
+  async get(id: string): Promise<SalesOrderResponse> {
+    const response = await this.stateset.request('GET', `salesorders/${id}`);
+    return this.handleCommandResponse({ update_salesorders_by_pk: response });
+  }
+
+  async create(data: SalesOrderData): Promise<SalesOrderResponse> {
+    const response = await this.stateset.request('POST', 'salesorders', data);
+    return this.handleCommandResponse(response);
+  }
+
+  async update(id: string, data: Partial<SalesOrderData>): Promise<SalesOrderResponse> {
+    const response = await this.stateset.request('PUT', `salesorders/${id}`, data);
+    return this.handleCommandResponse(response);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.stateset.request('DELETE', `salesorders/${id}`);
+  }
+
+  async submit(id: string): Promise<SubmittedSalesOrderResponse> {
+    const response = await this.stateset.request('POST', `salesorders/${id}/submit`);
+    return this.handleCommandResponse(response) as SubmittedSalesOrderResponse;
+  }
+
+  async fulfill(id: string): Promise<FulfilledSalesOrderResponse> {
+    const response = await this.stateset.request('POST', `salesorders/${id}/fulfill`);
+    return this.handleCommandResponse(response) as FulfilledSalesOrderResponse;
+  }
+
+  async invoice(id: string): Promise<InvoicedSalesOrderResponse> {
+    const response = await this.stateset.request('POST', `salesorders/${id}/invoice`);
+    return this.handleCommandResponse(response) as InvoicedSalesOrderResponse;
+  }
+
+  async pay(id: string): Promise<PaidSalesOrderResponse> {
+    const response = await this.stateset.request('POST', `salesorders/${id}/pay`);
+    return this.handleCommandResponse(response) as PaidSalesOrderResponse;
+  }
+
+  async cancel(id: string): Promise<CancelledSalesOrderResponse> {
+    const response = await this.stateset.request('POST', `salesorders/${id}/cancel`);
+    return this.handleCommandResponse(response) as CancelledSalesOrderResponse;
+  }
+}
+
+export default SalesOrders;

--- a/src/stateset-client.ts
+++ b/src/stateset-client.ts
@@ -69,6 +69,10 @@ import DeliveryConfirmations from './lib/resources/DeliveryConfirmation';
 import Activities from './lib/resources/Activities';
 import Fulfillment from './lib/resources/Fulfillment';
 import ProductionJob from './lib/resources/ProductionJob';
+import SalesOrders from './lib/resources/SalesOrder';
+import FulfillmentOrders from './lib/resources/FulfillmentOrder';
+import ItemReceipts from './lib/resources/ItemReceipt';
+import CashSales from './lib/resources/CashSale';
 
 interface StatesetOptions {
   apiKey?: string;
@@ -172,6 +176,10 @@ export class stateset {
   public activities: Activities;
   public fulfillment: Fulfillment;
   public productionJob: ProductionJob;
+  public salesOrders: SalesOrders;
+  public fulfillmentOrders: FulfillmentOrders;
+  public itemReceipts: ItemReceipts;
+  public cashSales: CashSales;
 
   constructor(options: StatesetOptions) {
     this.apiKey = options.apiKey || process.env.STATESET_API_KEY || '';
@@ -291,6 +299,10 @@ export class stateset {
     this.activities = new Activities(this);
     this.fulfillment = new Fulfillment(this);
     this.productionJob = new ProductionJob(this);
+    this.salesOrders = new SalesOrders(this);
+    this.fulfillmentOrders = new FulfillmentOrders(this);
+    this.itemReceipts = new ItemReceipts(this);
+    this.cashSales = new CashSales(this);
   }
 
   /**


### PR DESCRIPTION
## Summary
- implement SalesOrder, FulfillmentOrder, ItemReceipt and CashSale resource modules
- expose new resources from the Stateset client
- extend tests to cover the new modules

## Testing
- `npm test`