### PR TITLE
Add compiled commerce resources

### DIFF
--- a/dist/lib/resources/CashSale.d.ts
+++ b/dist/lib/resources/CashSale.d.ts
@@ -1,0 +1,50 @@
+import { stateset } from '../../stateset-client';
+export type CashSaleStatus = 'PENDING' | 'COMPLETED' | 'CANCELLED' | 'REFUNDED';
+interface BaseCashSaleResponse {
+    id: string;
+    object: 'cashsale';
+    status: CashSaleStatus;
+}
+interface PendingCashSaleResponse extends BaseCashSaleResponse {
+    status: 'PENDING';
+    pending: true;
+}
+interface CompletedCashSaleResponse extends BaseCashSaleResponse {
+    status: 'COMPLETED';
+    completed: true;
+}
+interface CancelledCashSaleResponse extends BaseCashSaleResponse {
+    status: 'CANCELLED';
+    cancelled: true;
+}
+interface RefundedCashSaleResponse extends BaseCashSaleResponse {
+    status: 'REFUNDED';
+    refunded: true;
+}
+export type CashSaleResponse = PendingCashSaleResponse | CompletedCashSaleResponse | CancelledCashSaleResponse | RefundedCashSaleResponse;
+export interface CashSaleLine {
+    item_id: string;
+    quantity: number;
+    unit_price: number;
+    [key: string]: any;
+}
+export interface CashSaleData {
+    customer_id: string;
+    sale_date: string;
+    lines: CashSaleLine[];
+    [key: string]: any;
+}
+declare class CashSales {
+    private stateset;
+    constructor(stateset: stateset);
+    private handleCommandResponse;
+    list(): Promise<CashSaleResponse[]>;
+    get(id: string): Promise<CashSaleResponse>;
+    create(data: CashSaleData): Promise<CashSaleResponse>;
+    update(id: string, data: Partial<CashSaleData>): Promise<CashSaleResponse>;
+    delete(id: string): Promise<void>;
+    complete(id: string): Promise<CompletedCashSaleResponse>;
+    refund(id: string): Promise<RefundedCashSaleResponse>;
+    cancel(id: string): Promise<CancelledCashSaleResponse>;
+}
+export default CashSales;

--- a/dist/lib/resources/CashSale.js
+++ b/dist/lib/resources/CashSale.js
@@ -1,0 +1,65 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+class CashSales {
+    constructor(stateset) {
+        this.stateset = stateset;
+    }
+    handleCommandResponse(response) {
+        if (response.error) {
+            throw new Error(response.error);
+        }
+        if (!response.update_cashsales_by_pk) {
+            throw new Error('Unexpected response format');
+        }
+        const sale = response.update_cashsales_by_pk;
+        const base = {
+            id: sale.id,
+            object: 'cashsale',
+            status: sale.status,
+        };
+        switch (sale.status) {
+            case 'PENDING':
+                return { ...base, status: 'PENDING', pending: true };
+            case 'COMPLETED':
+                return { ...base, status: 'COMPLETED', completed: true };
+            case 'CANCELLED':
+                return { ...base, status: 'CANCELLED', cancelled: true };
+            case 'REFUNDED':
+                return { ...base, status: 'REFUNDED', refunded: true };
+            default:
+                throw new Error(`Unexpected cash sale status: ${sale.status}`);
+        }
+    }
+    async list() {
+        const response = await this.stateset.request('GET', 'cashsales');
+        return response.map((cs) => this.handleCommandResponse({ update_cashsales_by_pk: cs }));
+    }
+    async get(id) {
+        const response = await this.stateset.request('GET', `cashsales/${id}`);
+        return this.handleCommandResponse({ update_cashsales_by_pk: response });
+    }
+    async create(data) {
+        const response = await this.stateset.request('POST', 'cashsales', data);
+        return this.handleCommandResponse(response);
+    }
+    async update(id, data) {
+        const response = await this.stateset.request('PUT', `cashsales/${id}`, data);
+        return this.handleCommandResponse(response);
+    }
+    async delete(id) {
+        await this.stateset.request('DELETE', `cashsales/${id}`);
+    }
+    async complete(id) {
+        const response = await this.stateset.request('POST', `cashsales/${id}/complete`);
+        return this.handleCommandResponse(response);
+    }
+    async refund(id) {
+        const response = await this.stateset.request('POST', `cashsales/${id}/refund`);
+        return this.handleCommandResponse(response);
+    }
+    async cancel(id) {
+        const response = await this.stateset.request('POST', `cashsales/${id}/cancel`);
+        return this.handleCommandResponse(response);
+    }
+}
+exports.default = CashSales;

--- a/dist/lib/resources/FulfillmentOrder.d.ts
+++ b/dist/lib/resources/FulfillmentOrder.d.ts
@@ -1,0 +1,59 @@
+import { stateset } from '../../stateset-client';
+export type FulfillmentOrderStatus = 'OPEN' | 'ALLOCATED' | 'PICKED' | 'PACKED' | 'SHIPPED' | 'CANCELLED';
+interface BaseFulfillmentOrderResponse {
+    id: string;
+    object: 'fulfillmentorder';
+    status: FulfillmentOrderStatus;
+}
+interface OpenFulfillmentOrderResponse extends BaseFulfillmentOrderResponse {
+    status: 'OPEN';
+    open: true;
+}
+interface AllocatedFulfillmentOrderResponse extends BaseFulfillmentOrderResponse {
+    status: 'ALLOCATED';
+    allocated: true;
+}
+interface PickedFulfillmentOrderResponse extends BaseFulfillmentOrderResponse {
+    status: 'PICKED';
+    picked: true;
+}
+interface PackedFulfillmentOrderResponse extends BaseFulfillmentOrderResponse {
+    status: 'PACKED';
+    packed: true;
+}
+interface ShippedFulfillmentOrderResponse extends BaseFulfillmentOrderResponse {
+    status: 'SHIPPED';
+    shipped: true;
+}
+interface CancelledFulfillmentOrderResponse extends BaseFulfillmentOrderResponse {
+    status: 'CANCELLED';
+    cancelled: true;
+}
+export type FulfillmentOrderResponse = OpenFulfillmentOrderResponse | AllocatedFulfillmentOrderResponse | PickedFulfillmentOrderResponse | PackedFulfillmentOrderResponse | ShippedFulfillmentOrderResponse | CancelledFulfillmentOrderResponse;
+export interface FulfillmentOrderLine {
+    item_id: string;
+    quantity: number;
+    [key: string]: any;
+}
+export interface FulfillmentOrderData {
+    order_id: string;
+    warehouse_id: string;
+    lines: FulfillmentOrderLine[];
+    [key: string]: any;
+}
+declare class FulfillmentOrders {
+    private stateset;
+    constructor(stateset: stateset);
+    private handleCommandResponse;
+    list(): Promise<FulfillmentOrderResponse[]>;
+    get(id: string): Promise<FulfillmentOrderResponse>;
+    create(data: FulfillmentOrderData): Promise<FulfillmentOrderResponse>;
+    update(id: string, data: Partial<FulfillmentOrderData>): Promise<FulfillmentOrderResponse>;
+    delete(id: string): Promise<void>;
+    allocate(id: string): Promise<AllocatedFulfillmentOrderResponse>;
+    pick(id: string): Promise<PickedFulfillmentOrderResponse>;
+    pack(id: string): Promise<PackedFulfillmentOrderResponse>;
+    ship(id: string): Promise<ShippedFulfillmentOrderResponse>;
+    cancel(id: string): Promise<CancelledFulfillmentOrderResponse>;
+}
+export default FulfillmentOrders;

--- a/dist/lib/resources/FulfillmentOrder.js
+++ b/dist/lib/resources/FulfillmentOrder.js
@@ -1,0 +1,77 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+class FulfillmentOrders {
+    constructor(stateset) {
+        this.stateset = stateset;
+    }
+    handleCommandResponse(response) {
+        if (response.error) {
+            throw new Error(response.error);
+        }
+        if (!response.update_fulfillmentorders_by_pk) {
+            throw new Error('Unexpected response format');
+        }
+        const fo = response.update_fulfillmentorders_by_pk;
+        const base = {
+            id: fo.id,
+            object: 'fulfillmentorder',
+            status: fo.status,
+        };
+        switch (fo.status) {
+            case 'OPEN':
+                return { ...base, status: 'OPEN', open: true };
+            case 'ALLOCATED':
+                return { ...base, status: 'ALLOCATED', allocated: true };
+            case 'PICKED':
+                return { ...base, status: 'PICKED', picked: true };
+            case 'PACKED':
+                return { ...base, status: 'PACKED', packed: true };
+            case 'SHIPPED':
+                return { ...base, status: 'SHIPPED', shipped: true };
+            case 'CANCELLED':
+                return { ...base, status: 'CANCELLED', cancelled: true };
+            default:
+                throw new Error(`Unexpected fulfillment order status: ${fo.status}`);
+        }
+    }
+    async list() {
+        const response = await this.stateset.request('GET', 'fulfillmentorders');
+        return response.map((fo) => this.handleCommandResponse({ update_fulfillmentorders_by_pk: fo }));
+    }
+    async get(id) {
+        const response = await this.stateset.request('GET', `fulfillmentorders/${id}`);
+        return this.handleCommandResponse({ update_fulfillmentorders_by_pk: response });
+    }
+    async create(data) {
+        const response = await this.stateset.request('POST', 'fulfillmentorders', data);
+        return this.handleCommandResponse(response);
+    }
+    async update(id, data) {
+        const response = await this.stateset.request('PUT', `fulfillmentorders/${id}`, data);
+        return this.handleCommandResponse(response);
+    }
+    async delete(id) {
+        await this.stateset.request('DELETE', `fulfillmentorders/${id}`);
+    }
+    async allocate(id) {
+        const response = await this.stateset.request('POST', `fulfillmentorders/${id}/allocate`);
+        return this.handleCommandResponse(response);
+    }
+    async pick(id) {
+        const response = await this.stateset.request('POST', `fulfillmentorders/${id}/pick`);
+        return this.handleCommandResponse(response);
+    }
+    async pack(id) {
+        const response = await this.stateset.request('POST', `fulfillmentorders/${id}/pack`);
+        return this.handleCommandResponse(response);
+    }
+    async ship(id) {
+        const response = await this.stateset.request('POST', `fulfillmentorders/${id}/ship`);
+        return this.handleCommandResponse(response);
+    }
+    async cancel(id) {
+        const response = await this.stateset.request('POST', `fulfillmentorders/${id}/cancel`);
+        return this.handleCommandResponse(response);
+    }
+}
+exports.default = FulfillmentOrders;

--- a/dist/lib/resources/ItemReceipt.d.ts
+++ b/dist/lib/resources/ItemReceipt.d.ts
@@ -1,0 +1,48 @@
+import { stateset } from '../../stateset-client';
+export type ItemReceiptStatus = 'PENDING' | 'RECEIVED' | 'PARTIAL' | 'CANCELLED';
+interface BaseItemReceiptResponse {
+    id: string;
+    object: 'itemreceipt';
+    status: ItemReceiptStatus;
+}
+interface PendingItemReceiptResponse extends BaseItemReceiptResponse {
+    status: 'PENDING';
+    pending: true;
+}
+interface ReceivedItemReceiptResponse extends BaseItemReceiptResponse {
+    status: 'RECEIVED';
+    received: true;
+}
+interface PartialItemReceiptResponse extends BaseItemReceiptResponse {
+    status: 'PARTIAL';
+    partial: true;
+}
+interface CancelledItemReceiptResponse extends BaseItemReceiptResponse {
+    status: 'CANCELLED';
+    cancelled: true;
+}
+export type ItemReceiptResponse = PendingItemReceiptResponse | ReceivedItemReceiptResponse | PartialItemReceiptResponse | CancelledItemReceiptResponse;
+export interface ItemReceiptLine {
+    item_id: string;
+    quantity_received: number;
+    [key: string]: any;
+}
+export interface ItemReceiptData {
+    purchase_order_id: string;
+    lines: ItemReceiptLine[];
+    receipt_date: string;
+    [key: string]: any;
+}
+declare class ItemReceipts {
+    private stateset;
+    constructor(stateset: stateset);
+    private handleCommandResponse;
+    list(): Promise<ItemReceiptResponse[]>;
+    get(id: string): Promise<ItemReceiptResponse>;
+    create(data: ItemReceiptData): Promise<ItemReceiptResponse>;
+    update(id: string, data: Partial<ItemReceiptData>): Promise<ItemReceiptResponse>;
+    delete(id: string): Promise<void>;
+    receive(id: string): Promise<ReceivedItemReceiptResponse>;
+    cancel(id: string): Promise<CancelledItemReceiptResponse>;
+}
+export default ItemReceipts;

--- a/dist/lib/resources/ItemReceipt.js
+++ b/dist/lib/resources/ItemReceipt.js
@@ -1,0 +1,61 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+class ItemReceipts {
+    constructor(stateset) {
+        this.stateset = stateset;
+    }
+    handleCommandResponse(response) {
+        if (response.error) {
+            throw new Error(response.error);
+        }
+        if (!response.update_itemreceipts_by_pk) {
+            throw new Error('Unexpected response format');
+        }
+        const rec = response.update_itemreceipts_by_pk;
+        const base = {
+            id: rec.id,
+            object: 'itemreceipt',
+            status: rec.status,
+        };
+        switch (rec.status) {
+            case 'PENDING':
+                return { ...base, status: 'PENDING', pending: true };
+            case 'RECEIVED':
+                return { ...base, status: 'RECEIVED', received: true };
+            case 'PARTIAL':
+                return { ...base, status: 'PARTIAL', partial: true };
+            case 'CANCELLED':
+                return { ...base, status: 'CANCELLED', cancelled: true };
+            default:
+                throw new Error(`Unexpected item receipt status: ${rec.status}`);
+        }
+    }
+    async list() {
+        const response = await this.stateset.request('GET', 'itemreceipts');
+        return response.map((r) => this.handleCommandResponse({ update_itemreceipts_by_pk: r }));
+    }
+    async get(id) {
+        const response = await this.stateset.request('GET', `itemreceipts/${id}`);
+        return this.handleCommandResponse({ update_itemreceipts_by_pk: response });
+    }
+    async create(data) {
+        const response = await this.stateset.request('POST', 'itemreceipts', data);
+        return this.handleCommandResponse(response);
+    }
+    async update(id, data) {
+        const response = await this.stateset.request('PUT', `itemreceipts/${id}`, data);
+        return this.handleCommandResponse(response);
+    }
+    async delete(id) {
+        await this.stateset.request('DELETE', `itemreceipts/${id}`);
+    }
+    async receive(id) {
+        const response = await this.stateset.request('POST', `itemreceipts/${id}/receive`);
+        return this.handleCommandResponse(response);
+    }
+    async cancel(id) {
+        const response = await this.stateset.request('POST', `itemreceipts/${id}/cancel`);
+        return this.handleCommandResponse(response);
+    }
+}
+exports.default = ItemReceipts;

--- a/dist/lib/resources/SalesOrder.d.ts
+++ b/dist/lib/resources/SalesOrder.d.ts
@@ -1,0 +1,60 @@
+import { stateset } from '../../stateset-client';
+export type SalesOrderStatus = 'DRAFT' | 'SUBMITTED' | 'FULFILLED' | 'INVOICED' | 'PAID' | 'CANCELLED';
+interface BaseSalesOrderResponse {
+    id: string;
+    object: 'salesorder';
+    status: SalesOrderStatus;
+}
+interface DraftSalesOrderResponse extends BaseSalesOrderResponse {
+    status: 'DRAFT';
+    draft: true;
+}
+interface SubmittedSalesOrderResponse extends BaseSalesOrderResponse {
+    status: 'SUBMITTED';
+    submitted: true;
+}
+interface FulfilledSalesOrderResponse extends BaseSalesOrderResponse {
+    status: 'FULFILLED';
+    fulfilled: true;
+}
+interface InvoicedSalesOrderResponse extends BaseSalesOrderResponse {
+    status: 'INVOICED';
+    invoiced: true;
+}
+interface PaidSalesOrderResponse extends BaseSalesOrderResponse {
+    status: 'PAID';
+    paid: true;
+}
+interface CancelledSalesOrderResponse extends BaseSalesOrderResponse {
+    status: 'CANCELLED';
+    cancelled: true;
+}
+export type SalesOrderResponse = DraftSalesOrderResponse | SubmittedSalesOrderResponse | FulfilledSalesOrderResponse | InvoicedSalesOrderResponse | PaidSalesOrderResponse | CancelledSalesOrderResponse;
+export interface SalesOrderItem {
+    item_id: string;
+    quantity: number;
+    unit_price: number;
+    [key: string]: any;
+}
+export interface SalesOrderData {
+    customer_id: string;
+    order_date: string;
+    items: SalesOrderItem[];
+    [key: string]: any;
+}
+declare class SalesOrders {
+    private stateset;
+    constructor(stateset: stateset);
+    private handleCommandResponse;
+    list(): Promise<SalesOrderResponse[]>;
+    get(id: string): Promise<SalesOrderResponse>;
+    create(data: SalesOrderData): Promise<SalesOrderResponse>;
+    update(id: string, data: Partial<SalesOrderData>): Promise<SalesOrderResponse>;
+    delete(id: string): Promise<void>;
+    submit(id: string): Promise<SubmittedSalesOrderResponse>;
+    fulfill(id: string): Promise<FulfilledSalesOrderResponse>;
+    invoice(id: string): Promise<InvoicedSalesOrderResponse>;
+    pay(id: string): Promise<PaidSalesOrderResponse>;
+    cancel(id: string): Promise<CancelledSalesOrderResponse>;
+}
+export default SalesOrders;

--- a/dist/lib/resources/SalesOrder.js
+++ b/dist/lib/resources/SalesOrder.js
@@ -1,0 +1,77 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+class SalesOrders {
+    constructor(stateset) {
+        this.stateset = stateset;
+    }
+    handleCommandResponse(response) {
+        if (response.error) {
+            throw new Error(response.error);
+        }
+        if (!response.update_salesorders_by_pk) {
+            throw new Error('Unexpected response format');
+        }
+        const salesOrder = response.update_salesorders_by_pk;
+        const base = {
+            id: salesOrder.id,
+            object: 'salesorder',
+            status: salesOrder.status,
+        };
+        switch (salesOrder.status) {
+            case 'DRAFT':
+                return { ...base, status: 'DRAFT', draft: true };
+            case 'SUBMITTED':
+                return { ...base, status: 'SUBMITTED', submitted: true };
+            case 'FULFILLED':
+                return { ...base, status: 'FULFILLED', fulfilled: true };
+            case 'INVOICED':
+                return { ...base, status: 'INVOICED', invoiced: true };
+            case 'PAID':
+                return { ...base, status: 'PAID', paid: true };
+            case 'CANCELLED':
+                return { ...base, status: 'CANCELLED', cancelled: true };
+            default:
+                throw new Error(`Unexpected sales order status: ${salesOrder.status}`);
+        }
+    }
+    async list() {
+        const response = await this.stateset.request('GET', 'salesorders');
+        return response.map((so) => this.handleCommandResponse({ update_salesorders_by_pk: so }));
+    }
+    async get(id) {
+        const response = await this.stateset.request('GET', `salesorders/${id}`);
+        return this.handleCommandResponse({ update_salesorders_by_pk: response });
+    }
+    async create(data) {
+        const response = await this.stateset.request('POST', 'salesorders', data);
+        return this.handleCommandResponse(response);
+    }
+    async update(id, data) {
+        const response = await this.stateset.request('PUT', `salesorders/${id}`, data);
+        return this.handleCommandResponse(response);
+    }
+    async delete(id) {
+        await this.stateset.request('DELETE', `salesorders/${id}`);
+    }
+    async submit(id) {
+        const response = await this.stateset.request('POST', `salesorders/${id}/submit`);
+        return this.handleCommandResponse(response);
+    }
+    async fulfill(id) {
+        const response = await this.stateset.request('POST', `salesorders/${id}/fulfill`);
+        return this.handleCommandResponse(response);
+    }
+    async invoice(id) {
+        const response = await this.stateset.request('POST', `salesorders/${id}/invoice`);
+        return this.handleCommandResponse(response);
+    }
+    async pay(id) {
+        const response = await this.stateset.request('POST', `salesorders/${id}/pay`);
+        return this.handleCommandResponse(response);
+    }
+    async cancel(id) {
+        const response = await this.stateset.request('POST', `salesorders/${id}/cancel`);
+        return this.handleCommandResponse(response);
+    }
+}
+exports.default = SalesOrders;


### PR DESCRIPTION
## Summary
- include `SalesOrder`, `FulfillmentOrder`, `ItemReceipt` and `CashSale` modules in the build output

## Testing
- `npm test`
