### PR TITLE
Add proxy support to SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,15 @@ const client = new stateset({
   timeout: 60000,
   userAgent: 'my-app/1.0',
   // Additional headers sent with every request
-  additionalHeaders: { 'X-Customer-ID': 'abc123' }
+  additionalHeaders: { 'X-Customer-ID': 'abc123' },
+  // Optional HTTP proxy
+  proxy: 'http://localhost:3128'
 });
 ```
 
 Retry behaviour can also be configured using the `STATESET_RETRY` and
-`STATESET_RETRY_DELAY_MS` environment variables.
+`STATESET_RETRY_DELAY_MS` environment variables. Proxy settings can be provided
+via the `STATESET_PROXY` environment variable.
 
 ### Updating configuration after initialization
 
@@ -76,6 +79,7 @@ client.setBaseUrl('https://api.example.com');
 client.setTimeout(30000);
 client.setRetryOptions(5, 500);
 client.setHeaders({ 'X-Customer-ID': 'abc123' });
+client.setProxy('http://localhost:3128');
 ```
 
 3. **Make an API call**

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -57,6 +57,22 @@ test('applies additional headers from options', () => {
   expect(client.httpClient.defaults.headers['X-Example']).toBe('example');
 });
 
+test('supports proxy configuration', () => {
+  process.env.STATESET_PROXY = 'http://localhost:8080';
+  const clientEnv: any = new stateset({ apiKey: 'proxy-key' });
+  expect(clientEnv.httpClient.defaults.proxy.host).toBe('localhost');
+  expect(clientEnv.httpClient.defaults.proxy.port).toBe(8080);
+  delete process.env.STATESET_PROXY;
+
+  const clientOpt: any = new stateset({
+    apiKey: 'proxy-key',
+    proxy: 'http://example.com:3128'
+  });
+  expect(clientOpt.httpClient.defaults.proxy.host).toBe('example.com');
+  clientOpt.setProxy('http://another:9000');
+  expect(clientOpt.httpClient.defaults.proxy.port).toBe(9000);
+});
+
 test('exposes customer service helper methods', () => {
   const client: any = new stateset({ apiKey: 'test-key' });
   expect(typeof client.casesTickets.search).toBe('function');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stateset-node",
-  "version": "0.0.90",
+  "version": "0.0.91",
   "description": "TypeScript/Node.js library for the Stateset API",
   "keywords": [
     "stateset",


### PR DESCRIPTION
## Summary
- enable HTTP proxy configuration via client options or `STATESET_PROXY` env var
- document proxy usage in README
- expose `setProxy` method to update proxy settings
- bump package version to 0.0.91
- test proxy configuration behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684073e6e3a0832e802f95cbfe627af5