### PR TITLE
Improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,25 @@ try {
 }
 ```
 
+### Error handling
+
+All failed requests throw subclasses of `StatesetError`. You can check the
+instance type to handle specific cases:
+
+```javascript
+import { StatesetNotFoundError } from 'stateset-node';
+
+try {
+  await client.orders.get('ord_123');
+} catch (err) {
+  if (err instanceof StatesetNotFoundError) {
+    console.log('Order not found');
+  } else {
+    console.error('API request failed', err);
+  }
+}
+```
+
 ### Working with case tickets
 
 ```javascript

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -118,3 +118,13 @@ test('exposes newly added commerce resources', () => {
   expect(typeof client.itemReceipts.list).toBe('function');
   expect(typeof client.cashSales.list).toBe('function');
 });
+
+test('request method throws typed Stateset errors', async () => {
+  const client: any = new stateset({ apiKey: 'key' });
+  jest.spyOn(client.httpClient, 'request').mockRejectedValue({
+    response: { status: 404, data: { message: 'Not found' } },
+    config: { url: 'test' }
+  });
+  const { StatesetNotFoundError } = require('../src');
+  await expect(client.request('GET', 'missing')).rejects.toBeInstanceOf(StatesetNotFoundError);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,21 @@
 import { stateset } from './stateset-client';
 import OpenAIIntegration from './lib/integrations/OpenAIIntegration';
+import {
+  StatesetError,
+  StatesetAPIError,
+  StatesetAuthenticationError,
+  StatesetConnectionError,
+  StatesetInvalidRequestError,
+  StatesetNotFoundError
+} from './StatesetError';
 
 export default stateset;
-export { OpenAIIntegration };
+export {
+  OpenAIIntegration,
+  StatesetError,
+  StatesetAPIError,
+  StatesetAuthenticationError,
+  StatesetConnectionError,
+  StatesetInvalidRequestError,
+  StatesetNotFoundError
+};


### PR DESCRIPTION
## Summary
- expose custom error classes through public entrypoint
- raise typed errors from HTTP requests
- document the new error-handling API
- test that typed errors are thrown from the request method

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68407696f760832e9bc4aff7430fc346