### PR TITLE
Add app info support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ const client = new stateset({
   // Optional request timeout and custom User-Agent
   timeout: 60000,
   userAgent: 'my-app/1.0',
+  // Information about your app added to the User-Agent header
+  appInfo: { name: 'MyApp', version: '1.0', url: 'https://example.com' },
   // Additional headers sent with every request
   additionalHeaders: { 'X-Customer-ID': 'abc123' },
   // Optional HTTP proxy
@@ -80,6 +82,7 @@ client.setTimeout(30000);
 client.setRetryOptions(5, 500);
 client.setHeaders({ 'X-Customer-ID': 'abc123' });
 client.setProxy('http://localhost:3128');
+client.setAppInfo({ name: 'MyApp', version: '1.0', url: 'https://example.com' });
 ```
 
 3. **Make an API call**

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -73,6 +73,12 @@ test('supports proxy configuration', () => {
   expect(clientOpt.httpClient.defaults.proxy.port).toBe(9000);
 });
 
+test('allows setting app info for user agent', () => {
+  const client: any = new stateset({ apiKey: 'key' });
+  client.setAppInfo({ name: 'TestApp', version: '2.0', url: 'https://a.com' });
+  expect(client.httpClient.defaults.headers['User-Agent']).toMatch(/TestApp\/2.0/);
+});
+
 test('exposes customer service helper methods', () => {
   const client: any = new stateset({ apiKey: 'test-key' });
   expect(typeof client.casesTickets.search).toBe('function');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stateset-node",
-  "version": "0.0.91",
+  "version": "0.0.92",
   "description": "TypeScript/Node.js library for the Stateset API",
   "keywords": [
     "stateset",


### PR DESCRIPTION
## Summary
- allow passing `appInfo` to the client constructor
- expose `setAppInfo` helper to update User-Agent
- document new option
- bump version to 0.0.92
- test custom app info

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841bc5351f4832e9d2933b4a52a1b24